### PR TITLE
Use akka.util.ByteString instead of Array[Byte]

### DIFF
--- a/project/ScalaRedisProject.scala
+++ b/project/ScalaRedisProject.scala
@@ -25,7 +25,7 @@ object ScalaRedisProject extends Build
           "org.slf4j"         %  "slf4j-log4j12"           % "1.7.5"         % "provided",
           "log4j"             %  "log4j"                   % "1.2.17"        % "provided",
           "junit"             %  "junit"                   % "4.11"          % "test",
-          "org.scalatest"     %  "scalatest_2.10"          % "2.0.M6-SNAP28" % "test"),
+          "org.scalatest"     %  "scalatest_2.10"          % "2.0.M6-SNAP34" % "test"),
     parallelExecution in Test := false,
     publishTo <<= version { (v: String) => 
       val nexus = "https://oss.sonatype.org/" 

--- a/src/main/scala/com/redis/Command.scala
+++ b/src/main/scala/com/redis/Command.scala
@@ -3,22 +3,24 @@ package com.redis
 import scala.concurrent.Promise
 import scala.util.Try
 import ProtocolUtils._
+import akka.util.{ByteString, ByteStringBuilder}
+
 
 sealed trait RedisCommand {
   // command returns Option[Ret]
   type Ret
 
   // command input : the request protocol of redis (upstream)
-  val line: Array[Byte]
+  val line: ByteString
 
   // the promise which will be set by the command
   lazy val promise = Promise[Ret]
 
   // mapping of redis reply to the final return type
-  val ret: Array[Byte] => Ret
+  val ret: ByteString => Ret
 
   // processing pipeline (downstream)
-  final def execute(s: Array[Byte]): Promise[Ret] = promise complete Try(ret(s))
+  final def execute(s: ByteString): Promise[Ret] = promise complete Try(ret(s))
 }
 
 trait StringCommand       extends RedisCommand
@@ -42,14 +44,16 @@ object RedisCommand {
   def flattenPairs(in: Iterable[Product2[Any, Any]]): List[Any] =
     in.iterator.flatMap(x => Iterator(x._1, x._2)).toList
   
-  def multiBulk(args: Seq[Array[Byte]]): Array[Byte] = {
-    val b = new scala.collection.mutable.ArrayBuilder.ofByte
-    b ++= "*%d".format(args.size).getBytes
+  def multiBulk(args: Seq[String]): ByteString = {
+    val b = new ByteStringBuilder
+    b += Multi
+    b ++= ByteString(args.size.toString)
     b ++= LS
     args foreach { arg =>
-      b ++= "$%d".format(arg.size).getBytes
+      b += Bulk
+      b ++= ByteString(arg.size.toString)
       b ++= LS
-      b ++= arg
+      b ++= ByteString(arg)
       b ++= LS
     }
     b.result

--- a/src/main/scala/com/redis/HashCommands.scala
+++ b/src/main/scala/com/redis/HashCommands.scala
@@ -8,74 +8,76 @@ import RedisCommand._
 import RedisReplies._
 import akka.pattern.ask
 import akka.actor._
+import akka.util.ByteString
+
 
 object HashCommands {
   case class HSet(key: Any, field: Any, value: Any, nx: Boolean = false)(implicit format: Format) extends HashCommand {
     type Ret = Boolean
     val line = multiBulk(
-      (if (nx) "HSETNX" else "HSET").getBytes("UTF-8") +: (List(key, field, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+      (if (nx) "HSETNX" else "HSET") +: (List(key, field, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class HGet[A](key: Any, field: Any)(implicit format: Format, parse: Parse[A]) extends HashCommand {
     type Ret = Option[A]
-    val line = multiBulk("HGET".getBytes("UTF-8") +: (List(key, field) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("HGET" +: (List(key, field) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class HMSet(key: Any, map: Iterable[Product2[Any,Any]])(implicit format: Format) extends HashCommand {
     type Ret = Boolean
-    val line = multiBulk("HMSET".getBytes("UTF-8") +: ((key :: flattenPairs(map)) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("HMSET" +: ((key :: flattenPairs(map)) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class HMGet[K,V](key: Any, fields: K*)(implicit format: Format, parseV: Parse[V]) extends HashCommand {
     type Ret = Map[K, V]
-    val line = multiBulk("HMGET".getBytes("UTF-8") +: ((key :: fields.toList) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList.zip(fields).collect {
+    val line = multiBulk("HMGET" +: ((key :: fields.toList) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList.zip(fields).collect {
       case (Some(value), field) => (field, value)
     }.toMap
   }
   
   case class HIncrby(key: Any, field: Any, value: Int)(implicit format: Format) extends HashCommand {
     type Ret = Long
-    val line = multiBulk("HINCRBY".getBytes("UTF-8") +: (List(key, field, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("HINCRBY" +: (List(key, field, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class HExists(key: Any, field: Any)(implicit format: Format) extends HashCommand {
     type Ret = Boolean
-    val line = multiBulk("HEXISTS".getBytes("UTF-8") +: (List(key, field) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("HEXISTS" +: (List(key, field) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class HDel(key: Any, field: Any, fields: Any*)(implicit format: Format) extends HashCommand {
     type Ret = Long
-    val line = multiBulk("HDEL".getBytes("UTF-8") +: ((key :: field :: fields.toList) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("HDEL" +: ((key :: field :: fields.toList) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class HLen(key: Any)(implicit format: Format) extends HashCommand {
     type Ret = Long
-    val line = multiBulk("HLEN".getBytes("UTF-8") +: (List(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("HLEN" +: (List(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class HKeys[A](key: Any)(implicit format: Format, parse: Parse[A]) extends HashCommand {
     type Ret = List[A]
-    val line = multiBulk("HKEYS".getBytes("UTF-8") +: (List(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList.flatten // TODO remove intermediate Option
+    val line = multiBulk("HKEYS" +: (List(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList.flatten // TODO remove intermediate Option
   }
   
   case class HVals[A](key: Any)(implicit format: Format, parse: Parse[A]) extends HashCommand {
     type Ret = List[A]
-    val line = multiBulk("HVALS".getBytes("UTF-8") +: (List(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList.flatten // TODO remove intermediate Option
+    val line = multiBulk("HVALS" +: (List(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList.flatten // TODO remove intermediate Option
   }
   
   case class HGetall[K,V](key: Any)(implicit format: Format, parseK: Parse[K], parseV: Parse[V]) extends HashCommand {
     type Ret = Map[K, V]
-    val line = multiBulk("HGETALL".getBytes("UTF-8") +: (List(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asListPairs[K,V].flatten.toMap // TODO remove intermediate Option
+    val line = multiBulk("HGETALL" +: (List(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asListPairs[K,V].flatten.toMap // TODO remove intermediate Option
   }
 }

--- a/src/main/scala/com/redis/KeyCommands.scala
+++ b/src/main/scala/com/redis/KeyCommands.scala
@@ -4,96 +4,98 @@ import serialization._
 import Parse.{Implicits => Parsers}
 import RedisCommand._
 import RedisReplies._
+import akka.util.ByteString
+
 
 object KeyCommands {
   case class Keys[A](pattern: Any = "*")(implicit format: Format, parse: Parse[A]) extends KeyCommand {
     type Ret = List[A]
-    val line = multiBulk("KEYS".getBytes("UTF-8") +: Seq(format.apply(pattern)))
-    val ret  = RedisReply(_: Array[Byte]).asList.flatten // TODO remove intermediate Option
+    val line = multiBulk("KEYS" +: Seq(format.apply(pattern)))
+    val ret  = RedisReply(_: ByteString).asList.flatten // TODO remove intermediate Option
   }
 
   case class RandomKey[A](implicit parse: Parse[A]) extends KeyCommand {
     type Ret = Option[A]
-    val line = multiBulk(Seq("RANDOMKEY".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk(Seq("RANDOMKEY"))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
 
   case class Rename(oldKey: Any, newKey: Any, nx: Boolean = false)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk((if (nx) "RENAMENX" else "RENAME").getBytes("UTF-8") +: (Seq(oldKey, newKey) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk((if (nx) "RENAMENX" else "RENAME") +: (Seq(oldKey, newKey) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object DBSize extends KeyCommand {
     type Ret = Long
-    val line = multiBulk(Seq("DBSIZE".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk(Seq("DBSIZE"))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class Exists(key: Any)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk("EXISTS".getBytes("UTF-8") +: Seq(format.apply(key)))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("EXISTS" +: Seq(format.apply(key)))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class Del(key: Any, keys: Any*)(implicit format: Format) extends KeyCommand {
     type Ret = Long
-    val line = multiBulk("DEL".getBytes("UTF-8") +: ((key :: keys.toList) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("DEL" +: ((key :: keys.toList) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class GetType(key: Any)(implicit format: Format) extends KeyCommand {
     type Ret = String
-    val line = multiBulk("TYPE".getBytes("UTF-8") +: Seq(format.apply(key)))
-    val ret  = RedisReply(_: Array[Byte]).asString
+    val line = multiBulk("TYPE" +: Seq(format.apply(key)))
+    val ret  = RedisReply(_: ByteString).asString
   }
 
   case class Expire(key: Any, ttl: Int, millis: Boolean = false)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk((if (millis) "PEXPIRE" else "EXPIRE").getBytes("UTF-8") +: (Seq(key, ttl) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk((if (millis) "PEXPIRE" else "EXPIRE") +: (Seq(key, ttl) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class ExpireAt(key: Any, timestamp: Long, millis: Boolean = false)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk((if (millis) "PEXPIREAT" else "EXPIREAT").getBytes("UTF-8") +: (Seq(key, timestamp) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk((if (millis) "PEXPIREAT" else "EXPIREAT") +: (Seq(key, timestamp) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class TTL(key: Any, millis: Boolean = false)(implicit format: Format) extends KeyCommand {
     type Ret = Long
-    val line = multiBulk((if (millis) "PTTL" else "TTL").getBytes("UTF-8") +: Seq(format.apply(key)))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk((if (millis) "PTTL" else "TTL") +: Seq(format.apply(key)))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class FlushDB(all: Boolean = false) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq((if (all) "FLUSHALL" else "FLUSHDB").getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq(if (all) "FLUSHALL" else "FLUSHDB"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class Move(key: Any, db: Int)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk("MOVE".getBytes("UTF-8") +: (Seq(key, db) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("MOVE" +: (Seq(key, db) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object Quit extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("QUIT".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("QUIT"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class Auth(secret: Any)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk("AUTH".getBytes("UTF-8") +: (Seq(secret) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("AUTH" +: (Seq(secret) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class Persist(key: Any)(implicit format: Format) extends KeyCommand {
     type Ret = Boolean
-    val line = multiBulk("PERSIST".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("PERSIST" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   // case class Select ..

--- a/src/main/scala/com/redis/ListCommands.scala
+++ b/src/main/scala/com/redis/ListCommands.scala
@@ -8,103 +8,105 @@ import RedisCommand._
 import RedisReplies._
 import akka.pattern.ask
 import akka.actor._
+import akka.util.ByteString
+
 
 object ListCommands {
   case class LPush(key: Any, value: Any, values: Any*)(implicit format: Format) extends ListCommand {
     type Ret = Long
-    val line = multiBulk("LPUSH".getBytes("UTF-8") +: (key :: value :: values.toList) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("LPUSH" +: (key :: value :: values.toList) map format.apply)
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class LPushX(key: Any, value: Any)(implicit format: Format) extends ListCommand {
     type Ret = Long
-    val line = multiBulk("LPUSHX".getBytes("UTF-8") +: (Seq(key, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("LPUSHX" +: (Seq(key, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class RPush(key: Any, value: Any, values: Any*)(implicit format: Format) extends ListCommand {
     type Ret = Long
-    val line = multiBulk("RPUSH".getBytes("UTF-8") +: (key :: value :: values.toList) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("RPUSH" +: (key :: value :: values.toList) map format.apply)
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class RPushX(key: Any, value: Any)(implicit format: Format) extends ListCommand {
     type Ret = Long
-    val line = multiBulk("RPUSHX".getBytes("UTF-8") +: (Seq(key, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("RPUSHX" +: (Seq(key, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class LRange[A](key: Any, start: Int, stop: Int)(implicit format: Format, parse: Parse[A]) extends ListCommand {
     type Ret = List[A]
-    val line = multiBulk("LRANGE".getBytes("UTF-8") +: (Seq(key, start, stop) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList[A].flatten // TODO Remove intermediate Option[A]
+    val line = multiBulk("LRANGE" +: (Seq(key, start, stop) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList[A].flatten // TODO Remove intermediate Option[A]
   }
 
   case class LLen(key: Any)(implicit format: Format) extends ListCommand {
     type Ret = Long
-    val line = multiBulk("LLEN".getBytes("UTF-8") +: (Seq(format.apply(key))))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("LLEN" +: (Seq(format.apply(key))))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class LTrim(key: Any, start: Int, end: Int)(implicit format: Format) extends ListCommand {
     type Ret = Boolean
-    val line = multiBulk("LTRIM".getBytes("UTF-8") +: (Seq(key, start, end) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("LTRIM" +: (Seq(key, start, end) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class LIndex[A](key: Any, index: Int)(implicit format: Format, parse: Parse[A]) extends ListCommand {
     type Ret = Option[A]
-    val line = multiBulk("LINDEX".getBytes("UTF-8") +: (Seq(key, index) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("LINDEX" +: (Seq(key, index) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
 
   case class LSet(key: Any, index: Int, value: Any)(implicit format: Format) extends ListCommand {
     type Ret = Boolean
-    val line = multiBulk("LSET".getBytes("UTF-8") +: (Seq(key, index, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("LSET" +: (Seq(key, index, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class LRem(key: Any, count: Int, value: Any)(implicit format: Format) extends ListCommand {
     type Ret = Long
-    val line = multiBulk("LREM".getBytes("UTF-8") +: (Seq(key, count, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("LREM" +: (Seq(key, count, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class LPop[A](key: Any)(implicit format: Format, parse: Parse[A]) extends ListCommand {
     type Ret = Option[A]
-    val line = multiBulk("LPOP".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("LPOP" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class RPop[A](key: Any)(implicit format: Format, parse: Parse[A]) extends ListCommand {
     type Ret = Option[A]
-    val line = multiBulk("RPOP".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("RPOP" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class RPopLPush[A](srcKey: Any, dstKey: Any)(implicit format: Format, parse: Parse[A]) extends ListCommand {
     type Ret = Option[A]
-    val line = multiBulk("RPOPLPUSH".getBytes("UTF-8") +: (Seq(srcKey, dstKey) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("RPOPLPUSH" +: (Seq(srcKey, dstKey) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class BRPopLPush[A](srcKey: Any, dstKey: Any, timeoutInSeconds: Int)(implicit format: Format, parse: Parse[A]) extends ListCommand {
     type Ret = Option[A]
-    val line = multiBulk("BRPOPLPUSH".getBytes("UTF-8") +: (Seq(srcKey, dstKey, timeoutInSeconds) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("BRPOPLPUSH" +: (Seq(srcKey, dstKey, timeoutInSeconds) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class BLPop[K, V](timeoutInSeconds: Int, key: K, keys: K*)
     (implicit format: Format, parseK: Parse[K], parseV: Parse[V]) extends ListCommand {
     type Ret = Option[(K, V)]
-    val line = multiBulk("BLPOP".getBytes("UTF-8") +: ((key :: keys.foldRight(List[Any](timeoutInSeconds))(_ :: _)) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asListPairs[K,V].flatten.headOption
+    val line = multiBulk("BLPOP" +: ((key :: keys.foldRight(List[Any](timeoutInSeconds))(_ :: _)) map format.apply))
+    val ret  = RedisReply(_: ByteString).asListPairs[K,V].flatten.headOption
   }
   
   case class BRPop[K, V](timeoutInSeconds: Int, key: K, keys: K*)
     (implicit format: Format, parseK: Parse[K], parseV: Parse[V]) extends ListCommand {
     type Ret = Option[(K, V)]
-    val line = multiBulk("BRPOP".getBytes("UTF-8") +: ((key :: keys.foldRight(List[Any](timeoutInSeconds))(_ :: _)) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asListPairs[K,V].flatten.headOption
+    val line = multiBulk("BRPOP" +: ((key :: keys.foldRight(List[Any](timeoutInSeconds))(_ :: _)) map format.apply))
+    val ret  = RedisReply(_: ByteString).asListPairs[K,V].flatten.headOption
   }
 }

--- a/src/main/scala/com/redis/NodeCommands.scala
+++ b/src/main/scala/com/redis/NodeCommands.scala
@@ -4,101 +4,103 @@ import serialization._
 import Parse.{Implicits => Parsers}
 import RedisCommand._
 import RedisReplies._
+import akka.util.ByteString
+
 
 object NodeCommands {
 
   case class Save(bg: Boolean = false) extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq((if (bg) "BGSAVE" else "SAVE").getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq((if (bg) "BGSAVE" else "SAVE")))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object LastSave extends NodeCommand {
     type Ret = Long
-    val line = multiBulk(Seq("LASTSAVE".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk(Seq("LASTSAVE"))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case object Shutdown extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("SHUTDOWN".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("SHUTDOWN"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object BGRewriteAOF extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("BGREWRITEAOF".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("BGREWRITEAOF"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class Info(section: String) extends NodeCommand {
     type Ret = Option[String]
-    val line = multiBulk(Seq("INFO", section).map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBulk
+    val line = multiBulk(Seq("INFO", section))
+    val ret  = RedisReply(_: ByteString).asBulk
   }
 
   case object Monitor extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("MONITOR".getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("MONITOR"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class SlaveOf(options: Any)(implicit format: Format) extends NodeCommand {
     type Ret = Boolean
     val line = multiBulk(
       options match {
-        case (h: String, p: Int) => "SLAVEOF".getBytes("UTF-8") +: (Seq(h, p) map format.apply)
-        case _ => Seq("SLAVEOF", "NO", "ONE").map(_.getBytes("UTF-8"))
+        case (h: String, p: Int) => "SLAVEOF" +: (Seq(h, p) map format.apply)
+        case _ => Seq("SLAVEOF", "NO", "ONE")
       }
     )
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object ClientGetName extends NodeCommand {
     type Ret = Option[String]
-    val line = multiBulk(Seq("CLIENT", "GETNAME").map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBulk
+    val line = multiBulk(Seq("CLIENT", "GETNAME"))
+    val ret  = RedisReply(_: ByteString).asBulk
   }
 
   case class ClientSetName(name: String) extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("CLIENT", "SETNAME", name).map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("CLIENT", "SETNAME", name))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class ClientKill(ipPort: String) extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("CLIENT", "KILL", ipPort).map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("CLIENT", "KILL", ipPort))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object ClientList extends NodeCommand {
     type Ret = Option[String]
-    val line = multiBulk(Seq("CLIENT", "LIST").map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBulk
+    val line = multiBulk(Seq("CLIENT", "LIST"))
+    val ret  = RedisReply(_: ByteString).asBulk
   }
 
   case class ConfigGet(globStyleParam: String) extends NodeCommand {
     type Ret = Option[String]
-    val line = multiBulk(Seq("CONFIG", "GET", globStyleParam).map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBulk
+    val line = multiBulk(Seq("CONFIG", "GET", globStyleParam))
+    val ret  = RedisReply(_: ByteString).asBulk
   }
 
   case class ConfigSet(param: String, value: Any)(implicit format: Format) extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk("CONFIG".getBytes("UTF-8") +: (Seq("SET", param, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("CONFIG" +: (Seq("SET", param, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object ConfigResetStat extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("CONFIG", "RESETSTAT").map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("CONFIG", "RESETSTAT"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case object ConfigRewrite extends NodeCommand {
     type Ret = Boolean
-    val line = multiBulk(Seq("CONFIG", "REWRITE").map(_.getBytes("UTF-8")))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk(Seq("CONFIG", "REWRITE"))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 }

--- a/src/main/scala/com/redis/ProtocolUtils.scala
+++ b/src/main/scala/com/redis/ProtocolUtils.scala
@@ -1,5 +1,6 @@
 package com.redis
 
+import akka.util.ByteString
 import annotation.tailrec
 
 object ProtocolUtils {
@@ -7,124 +8,70 @@ object ProtocolUtils {
   /**
    * Response codes from the Redis server
    */
-  val ERR                 = '-'
-  val OK                  = "OK".getBytes("UTF-8")
-  val QUEUED              = "QUEUED".getBytes("UTF-8")
-  val Array(minus, one)   = "-1".getBytes("UTF-8")
-  val SINGLE              = '+'
-  val BULK                = '$'
-  val MULTI               = '*'
-  val INT                 = ':'
+  val Cr      = '\r'.toByte
+  val Lf      = '\n'.toByte
+  val Status  = '+'.toByte
+  val Integer = ':'.toByte
+  val Bulk    = '$'.toByte
+  val Multi   = '*'.toByte
+  val Err     = '-'.toByte
 
-  val LS               = "\r\n".getBytes("UTF-8")
+  val Ok      = ByteString("OK")
+  val Queued  = ByteString("QUEUED")
+  val LS      = ByteString("\r\n")
 
-  val _cr: Byte        = '\r'.toByte
-  val _lf: Byte        = '\n'.toByte
-  val _single: Byte    = '+'.toByte
-  val _int: Byte       = ':'.toByte
-  val _bulk: Byte      = '$'.toByte
-  val _multi: Byte     = '*'.toByte
-  val _err: Byte       = '-'.toByte
-
-  val NULL_BULK_REPLY_COUNT = -1
+  val NullBulkReplyCount = -1
 
   /**
-   * splits an Array[Byte] at a pattern of byte sequence.
+   * split a ByteString at a pattern of byte sequence.
    */
-  def split(bytes: Array[Byte], delim: Seq[Byte] = Seq(_cr, _lf)): List[Array[Byte]] = {
+  def split(bytes: ByteString, delim: Seq[Byte] = Seq(Cr, Lf)): Vector[ByteString] = {
 
-    val matchesNoneOfDelim = (x: Byte) => delim forall (_ != x)
+    @tailrec
+    def inner(bytes: ByteString, acc: Vector[ByteString]): Vector[ByteString] =
+      if (bytes.isEmpty) acc
+      else {
+        val (line, rest) = bytes span ( ! delim.contains(_))
+        inner(rest.drop(2), acc :+ line)
+      }
 
-    @tailrec def split_a(bytes: Array[Byte], acc: List[Array[Byte]], inter: Array[Byte]): List[Array[Byte]] = bytes match {
-      case Array(cr, lf, rest@_*) if cr == _cr && lf == _lf => split_a(rest.toArray, acc ::: List(inter), Array.empty[Byte])
-      case Array(x, rest@_*) if matchesNoneOfDelim(x) => split_a(rest.toArray, acc, inter :+ x)
-      case Array() => acc
-    }
-    split_a(bytes, List.empty[Array[Byte]], Array.empty[Byte])
+    inner(bytes, Vector.empty[ByteString])
   }
 
   /**
-   * split an Array[Byte] of multiple replies into a collection of separate replies
-   * @todo : need to ahndle error replies
+   * split a ByteString of multiple replies into a collection of separate replies
+   * @todo : need to handle error replies
    */ 
-  def splitReplies(bytes: Array[Byte]): List[Array[Byte]] = {
-    def splitReplies_a(bytes: Array[Byte], acc: List[Array[Byte]]): List[Array[Byte]] = bytes match {
-      // handle sequence beginning with status reply
-      case Array(single, x, y, cr, lf, rest@_*) if single == _single && cr == _cr && lf == _lf => {
-        splitReplies_a(rest.toArray, acc ::: List(Array[Byte](_single, x, y, _cr, _lf)))
-      }
+  def splitReplies(bytes: ByteString): Vector[ByteString] = {
 
-      // handle sequence beginning with error reply
-      case Array(err, rest@_*) if err == _err => {
-        val (x, y) = rest.toArray.splitAt(rest.indexOfSlice(List(_cr, _lf)) + 2)
-        splitReplies_a(y.toArray, acc ::: List(_err +: x))
-      }
+    def inner(bytes: ByteString, acc: Vector[ByteString]): Vector[ByteString] =
+      if (bytes.isEmpty) acc
+      else {
+        val (head, rest) = bytes splitAt (bytes.indexOfSlice(LS) + 2)
 
-      // handle sequence beginning with integer reply
-      case Array(int, rest@_*) if int == _int => {
-        val (x, y) = rest.toArray.splitAt(rest.indexOfSlice(List(_cr, _lf)) + 2)
-        splitReplies_a(y.toArray, acc ::: List(_int +: x))
-      }
+        head(0) match {
+          case Bulk =>
+            val (l, a) = rest splitAt (rest.indexOfSlice(LS) + 2)
+            head.drop(1).dropRight(2).utf8String.toInt match {
+              case NullBulkReplyCount =>
+                inner(rest, acc :+ head)
 
-      // handle sequence beginning with bulk reply
+              case bodyLen =>
+                val (body, realRest) = rest splitAt (bodyLen + 2)
+                inner(realRest, acc :+ (head ++ body))
+            }
 
-      /**
-       * Bulk Reply:
-       *
-       * C: GET mykey
-       * S: $6\r\nfoobar\r\n
-       *
-       * Can be null - null bulk reply contains (-1) as the data length count
-       * C: GET nonexistingkey
-       * S: $-1
-       */
-      case Array(bulk, rest@_*) if bulk == _bulk => {
-        val (l, a) = rest.toArray.splitAt(rest.toArray.indexOfSlice(List(_cr, _lf)) + 2)
-        val bulkCount = new String(l.dropRight(2), "UTF-8").toInt
+          case Integer | Status | Err =>
+            inner(rest, acc :+ head)
 
-        if (bulkCount == NULL_BULK_REPLY_COUNT) {
-          splitReplies_a(a, acc ::: List(Array[Byte](_bulk) ++ l))
-        } else {
-          val (x, r) = a.splitAt(bulkCount + 2)
-          splitReplies_a(r, acc ::: List(Array[Byte](_bulk) ++ l ++ x))
+          case Multi =>
+            val msLen = head.drop(1).dropRight(2).utf8String.toInt
+            val replies = splitReplies(rest)
+            val (multiReplies, others) = replies.splitAt(msLen)
+            acc ++ Vector(head ++ multiReplies.fold(ByteString.empty)(_ ++ _)) ++ others
         }
       }
 
-      // handle sequence beginning with multi-bulk reply
-
-      /**
-       * Multi-Bulk Reply:
-       *
-       * C: LRANGE mylist 0 3
-       * S: *4
-       * S: $3
-       * S: foo
-       * S: $3
-       * S: bar
-       * S: $5
-       * S: Hello
-       * S: $5
-       * S: World
-       *
-       * Each bulk reply within the multi-bulk can be a null bulk as well. This should be
-       * fine and handled by the bulk reply pattern match.
-       *
-       * S: *3
-       * S: $3
-       * S: foo
-       * S: $-1
-       * S: $3
-       * S: bar
-       */
-      case Array(multi, rest@_*) if multi == _multi => { 
-        val(l, a) = rest.toArray.splitAt(rest.toArray.indexOfSlice(List(_cr, _lf)) + 2)
-        val r = splitReplies(a)
-        val no = new String(l.dropRight(2), "UTF-8").toInt
-        val (tojoin, others) = r.splitAt(no)
-        acc ::: List(Array[Byte](_multi) ++ l ++ tojoin.foldLeft(Array[Byte]())(_ ++ _)) ::: others
-      }
-      case Array() => acc
-    }
-    splitReplies_a(bytes, List.empty[Array[Byte]])
+    inner(bytes, Vector.empty[ByteString])
   }
 }

--- a/src/main/scala/com/redis/SetCommands.scala
+++ b/src/main/scala/com/redis/SetCommands.scala
@@ -9,6 +9,8 @@ import RedisReplies._
 import akka.pattern.ask
 import akka.actor._
 import akka.util.Timeout
+import akka.util.ByteString
+
 
 object SetCommands {
 
@@ -18,32 +20,32 @@ object SetCommands {
 
   case class SOp(op: Op, key: Any, value: Any, values: Any*)(implicit format: Format) extends SetCommand {
     type Ret = Long
-    val line = multiBulk((if (op == add) "SADD" else "SREM").getBytes("UTF-8") +: (key :: value :: values.toList) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk((if (op == add) "SADD" else "SREM") +: (key :: value :: values.toList) map format.apply)
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class SPop[A](key: Any)(implicit format: Format, parse: Parse[A]) extends SetCommand {
     type Ret = Option[A]
-    val line = multiBulk("SPOP".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("SPOP" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class SMove(srcKey: Any, destKey: Any, value: Any)(implicit format: Format) extends SetCommand {
     type Ret = Long
-    val line = multiBulk("SMOVE".getBytes("UTF-8") +: (Seq(srcKey, destKey, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("SMOVE" +: (Seq(srcKey, destKey, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class SCard(key: Any)(implicit format: Format) extends SetCommand {
     type Ret = Long
-    val line = multiBulk("SCARD".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("SCARD" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class ∈(key: Any, value: Any)(implicit format: Format) extends SetCommand {
     type Ret = Boolean
-    val line = multiBulk("SISMEMBER".getBytes("UTF-8") +: (Seq(key, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("SISMEMBER" +: (Seq(key, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   trait setOp 
@@ -54,32 +56,32 @@ object SetCommands {
   case class ∩∪∖[A](ux: setOp, key: Any, keys: Any*)(implicit format: Format, parse: Parse[A]) extends SetCommand {
     type Ret = Set[A]
     val line = multiBulk(
-      (if (ux == inter) "SINTER" else if (ux == union) "SUNION" else "SDIFF").getBytes("UTF-8") +: (key :: keys.toList) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asSet[A]
+      (if (ux == inter) "SINTER" else if (ux == union) "SUNION" else "SDIFF") +: (key :: keys.toList) map format.apply)
+    val ret  = RedisReply(_: ByteString).asSet[A]
   }
   
   case class SUXDStore(ux: setOp, destKey: Any, key: Any, keys: Any*)(implicit format: Format) extends SetCommand {
     type Ret = Long
     val line = multiBulk(
-      (if (ux == inter) "SINTERSTORE" else if (ux == union) "SUNIONSTORE" else "SDIFFSTORE").getBytes("UTF-8") +: (destKey :: key :: keys.toList) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asLong
+      (if (ux == inter) "SINTERSTORE" else if (ux == union) "SUNIONSTORE" else "SDIFFSTORE") +: (destKey :: key :: keys.toList) map format.apply)
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class SMembers[A](key: Any)(implicit format: Format, parse: Parse[A]) extends SetCommand {
     type Ret = Set[A]
-    val line = multiBulk("SDIFF".getBytes("UTF-8") +: Seq(key) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asSet[A]
+    val line = multiBulk("SDIFF" +: Seq(key) map format.apply)
+    val ret  = RedisReply(_: ByteString).asSet[A]
   }
 
   case class SRandMember[A](key: Any)(implicit format: Format, parse: Parse[A]) extends SetCommand {
     type Ret = Option[A]
-    val line = multiBulk("SRANDMEMBER".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("SRANDMEMBER" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
 
   case class SRandMembers[A](key: Any, count: Int)(implicit format: Format, parse: Parse[A]) extends SetCommand {
     type Ret = List[A]
-    val line = multiBulk("SRANDMEMBER".getBytes("UTF-8") +: (Seq(key, count) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList[A].flatten // TODO remove intermediate Option
+    val line = multiBulk("SRANDMEMBER" +: (Seq(key, count) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList[A].flatten // TODO remove intermediate Option
   }
 }

--- a/src/main/scala/com/redis/SortedSetCommands.scala
+++ b/src/main/scala/com/redis/SortedSetCommands.scala
@@ -8,39 +8,41 @@ import RedisCommand._
 import RedisReplies._
 import akka.pattern.ask
 import akka.actor._
+import akka.util.ByteString
+
 
 object SortedSetCommands {
   case class ZAdd(key: Any, score: Double, member: Any, scoreVals: (Double, Any)*)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
     val line = multiBulk(
-      "ZADD".getBytes("UTF-8") +: 
+      "ZADD" +:
       (List(key, score, member) ::: scoreVals.toList.map(x => List(x._1, x._2)).flatten) map format.apply
     )
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class ZRem(key: Any, member: Any, members: Any*)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
-    val line = multiBulk("ZREM".getBytes("UTF-8") +: (key :: member :: members.toList) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("ZREM" +: (key :: member :: members.toList) map format.apply)
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class ZIncrby(key: Any, incr: Double, member: Any)(implicit format: Format) extends SortedSetCommand {
     type Ret = Option[Double]
-    val line = multiBulk("ZINCRBY".getBytes("UTF-8") +: (Seq(key, incr, member) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk(Parse.Implicits.parseDouble)
+    val line = multiBulk("ZINCRBY" +: (Seq(key, incr, member) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk(Parse.Implicits.parseDouble)
   }
   
   case class ZCard(key: Any)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
-    val line = multiBulk("ZCARD".getBytes("UTF-8") +: (Seq(key) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("ZCARD" +: (Seq(key) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class ZScore(key: Any, element: Any)(implicit format: Format) extends SortedSetCommand {
     type Ret = Option[Double]
-    val line = multiBulk("ZSCORE".getBytes("UTF-8") +: (Seq(key, element) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk(Parse.Implicits.parseDouble)
+    val line = multiBulk("ZSCORE" +: (Seq(key, element) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk(Parse.Implicits.parseDouble)
   }
 
   case class ZRange[A](key: Any, start: Int = 0, end: Int = -1, sortAs: SortOrder = ASC)(implicit format: Format, parse: Parse[A]) 
@@ -48,8 +50,8 @@ object SortedSetCommands {
 
     type Ret = List[A]
     val line = multiBulk(
-      (if (sortAs == ASC) "ZRANGE" else "ZREVRANGE").getBytes("UTF-8") +: (Seq(key, start, end) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList.flatten // TODO remove intermediate Option
+      (if (sortAs == ASC) "ZRANGE" else "ZREVRANGE") +: (Seq(key, start, end) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList.flatten // TODO remove intermediate Option
   }
 
   case class ZRangeWithScore[A](key: Any, start: Int = 0, end: Int = -1, sortAs: SortOrder = ASC)(implicit format: Format, parse: Parse[A])
@@ -57,10 +59,10 @@ object SortedSetCommands {
 
     type Ret = List[(A, Double)]
     val line = multiBulk(
-      (if (sortAs == ASC) "ZRANGE" else "ZREVRANGE").getBytes("UTF-8") +: 
+      (if (sortAs == ASC) "ZRANGE" else "ZREVRANGE") +:
       (Seq(key, start, end, "WITHSCORES") map format.apply)
     )
-    val ret  = RedisReply(_: Array[Byte]).asListPairs(parse, Parse.Implicits.parseDouble).flatten
+    val ret  = RedisReply(_: ByteString).asListPairs(parse, Parse.Implicits.parseDouble).flatten
   }
 
   case class ZRangeByScore[A](key: Any,
@@ -76,10 +78,10 @@ object SortedSetCommands {
       zrangebyScoreWithScoreInternal(min, minInclusive, max, maxInclusive, limit)
 
     val line = multiBulk(
-      if (sortAs == ASC) "ZRANGEBYSCORE".getBytes("UTF-8") +: ((Seq(key, minParam, maxParam) ++ limitEntries) map format.apply)
-      else "ZREVRANGEBYSCORE".getBytes("UTF-8") +: ((Seq(key, maxParam, minParam) ++ limitEntries) map format.apply)
+      if (sortAs == ASC) "ZRANGEBYSCORE" +: ((Seq(key, minParam, maxParam) ++ limitEntries) map format.apply)
+      else "ZREVRANGEBYSCORE" +: ((Seq(key, maxParam, minParam) ++ limitEntries) map format.apply)
     )
-    val ret  = RedisReply(_: Array[Byte]).asList.flatten // TODO remove intermediate Option
+    val ret  = RedisReply(_: ByteString).asList.flatten // TODO remove intermediate Option
   }
 
   case class ZRangeByScoreWithScore[A](key: Any,
@@ -95,9 +97,9 @@ object SortedSetCommands {
       zrangebyScoreWithScoreInternal(min, minInclusive, max, maxInclusive, limit)
 
     val line = multiBulk(
-      if (sortAs == ASC) "ZRANGEBYSCORE".getBytes("UTF-8") +: ((Seq(key, minParam, maxParam, "WITHSCORES") ++ limitEntries) map format.apply)
-      else "ZREVRANGEBYSCORE".getBytes("UTF-8") +: ((Seq(key, maxParam, minParam, "WITHSCORES") ++ limitEntries) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asListPairs(parse, Parse.Implicits.parseDouble).flatten
+      if (sortAs == ASC) "ZRANGEBYSCORE" +: ((Seq(key, minParam, maxParam, "WITHSCORES") ++ limitEntries) map format.apply)
+      else "ZREVRANGEBYSCORE" +: ((Seq(key, maxParam, minParam, "WITHSCORES") ++ limitEntries) map format.apply))
+    val ret  = RedisReply(_: ByteString).asListPairs(parse, Parse.Implicits.parseDouble).flatten
   }
 
   private def zrangebyScoreWithScoreInternal[A](
@@ -122,20 +124,20 @@ object SortedSetCommands {
 
   case class ZRank(key: Any, member: Any, reverse: Boolean = false)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
-    val line = multiBulk((if (reverse) "ZREVRANK" else "ZRANK").getBytes("UTF-8") +: (Seq(key, member) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk((if (reverse) "ZREVRANK" else "ZRANK") +: (Seq(key, member) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class ZRemRangeByRank(key: Any, start: Int = 0, end: Int = -1)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
-    val line = multiBulk("ZREMRANGEBYRANK".getBytes("UTF-8") +: (Seq(key, start, end) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("ZREMRANGEBYRANK" +: (Seq(key, start, end) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class ZRemRangeByScore(key: Any, start: Double = Double.NegativeInfinity, end: Double = Double.PositiveInfinity)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
-    val line = multiBulk("ZREMRANGEBYSCORE".getBytes("UTF-8") +: (Seq(key, start, end) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("ZREMRANGEBYSCORE" +: (Seq(key, start, end) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   trait setOp 
@@ -147,10 +149,10 @@ object SortedSetCommands {
 
     type Ret = Long
     val line = multiBulk(
-      (if (ux == union) "ZUNIONSTORE" else "ZINTERSTORE").getBytes("UTF-8") +: 
+      (if (ux == union) "ZUNIONSTORE" else "ZINTERSTORE") +:
       ((Iterator(dstKey, keys.size) ++ keys.iterator ++ Iterator("AGGREGATE", aggregate)).toList) map format.apply
     )
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class ZUnionInterStoreWeighted(ux: setOp, dstKey: Any, kws: Iterable[Product2[Any,Double]], aggregate: Aggregate = SUM)
@@ -158,15 +160,15 @@ object SortedSetCommands {
 
     type Ret = Long
     val line = multiBulk(
-      (if (ux == union) "ZUNIONSTORE" else "ZINTERSTORE").getBytes("UTF-8") +: 
+      (if (ux == union) "ZUNIONSTORE" else "ZINTERSTORE") +:
       ((Iterator(dstKey, kws.size) ++ kws.iterator.map(_._1) ++ Iterator.single("WEIGHTS") ++ kws.iterator.map(_._2) ++ Iterator("AGGREGATE", aggregate)).toList) map format.apply
     )
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class ZCount(key: Any, min: Double = Double.NegativeInfinity, max: Double = Double.PositiveInfinity, minInclusive: Boolean = true, maxInclusive: Boolean = true)(implicit format: Format) extends SortedSetCommand {
     type Ret = Long
-    val line = multiBulk("ZCOUNT".getBytes("UTF-8") +: (List(key, Format.formatDouble(min, minInclusive), Format.formatDouble(max, maxInclusive)) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("ZCOUNT" +: (List(key, Format.formatDouble(min, minInclusive), Format.formatDouble(max, maxInclusive)) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 }

--- a/src/main/scala/com/redis/StringCommands.scala
+++ b/src/main/scala/com/redis/StringCommands.scala
@@ -8,12 +8,14 @@ import akka.pattern.ask
 import akka.actor._
 import RedisCommand._
 import RedisReplies._
+import akka.util.ByteString
+
 
 object StringCommands {
   case class Get[A](key: Any)(implicit format: Format, parse: Parse[A]) extends StringCommand {
     type Ret = Option[A]
-    val line = multiBulk("GET".getBytes("UTF-8") +: Seq(format.apply(key)))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("GET" +: Seq(format.apply(key)))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   sealed trait SetExpiryOption
@@ -28,7 +30,7 @@ object StringCommands {
     (implicit format: Format) extends StringCommand {
 
     type Ret = Boolean
-    val line = multiBulk("SET".getBytes("UTF-8") +: (Seq(key, value) ++  
+    val line = multiBulk("SET" +: (Seq(key, value) ++
       ((nxORxx, exORpx) match {
         case (Some(NX), Some(EX(n))) => Seq("EX", n, "NX")
         case (Some(XX), Some(EX(n))) => Seq("EX", n, "XX")
@@ -40,115 +42,115 @@ object StringCommands {
         case (Some(XX), None) => Seq("XX")
         case (None, None) => Seq.empty
       })) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class GetSet[A](key: Any, value: Any)(implicit format: Format, parse: Parse[A]) extends StringCommand {
     type Ret = Option[A]
-    val line = multiBulk("GETSET".getBytes("UTF-8") +: (Seq(key, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("GETSET" +: (Seq(key, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class SetNx(key: Any, value: Any)(implicit format: Format) extends StringCommand {
     type Ret = Boolean
-    val line = multiBulk("SETNX".getBytes("UTF-8") +: (Seq(key, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("SETNX" +: (Seq(key, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class SetEx(key: Any, expiry: Long, value: Any)(implicit format: Format) extends StringCommand {
     type Ret = Boolean
-    val line = multiBulk("SETEX".getBytes("UTF-8") +: (Seq(key, expiry, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("SETEX" +: (Seq(key, expiry, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class PSetEx(key: Any, expiryInMillis: Long, value: Any)(implicit format: Format) extends StringCommand {
     type Ret = Boolean
-    val line = multiBulk("PSETEX".getBytes("UTF-8") +: (Seq(key, expiryInMillis, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("PSETEX" +: (Seq(key, expiryInMillis, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class Incr(key: Any, by: Option[Int] = None)(implicit format: Format) extends StringCommand {
     type Ret = Long
     val line = multiBulk(
-      by.map(i => "INCRBY".getBytes("UTF-8") +: (Seq(key, i) map format.apply))
-        .getOrElse("INCR".getBytes("UTF-8") +: (Seq(format.apply(key))))
+      by.map(i => "INCRBY" +: (Seq(key, i) map format.apply))
+        .getOrElse("INCR" +: (Seq(format.apply(key))))
     )
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class Decr(key: Any, by: Option[Int] = None)(implicit format: Format) extends StringCommand {
     type Ret = Long
     val line = multiBulk(
-      by.map(i => "DECRBY".getBytes("UTF-8") +: (Seq(key, i) map format.apply))
-        .getOrElse("DECR".getBytes("UTF-8") +: (Seq(format.apply(key))))
+      by.map(i => "DECRBY" +: (Seq(key, i) map format.apply))
+        .getOrElse("DECR" +: (Seq(format.apply(key))))
     )
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class MGet[A](key: Any, keys: Any*)(implicit format: Format, parse: Parse[A]) extends StringCommand {
     type Ret = List[Option[A]]
-    val line = multiBulk("MGET".getBytes("UTF-8") +: ((key :: keys.toList) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asList[A]
+    val line = multiBulk("MGET" +: ((key :: keys.toList) map format.apply))
+    val ret  = RedisReply(_: ByteString).asList[A]
   }
 
   case class MSet(kvs: (Any, Any)*)(implicit format: Format) extends StringCommand {
     type Ret = Boolean
-    val line = multiBulk("MSET".getBytes("UTF-8") +: (kvs.foldRight(List[Any]()){ case ((k,v),l) => k :: v :: l }) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("MSET" +: (kvs.foldRight(List[Any]()){ case ((k,v),l) => k :: v :: l }) map format.apply)
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
 
   case class MSetNx(kvs: (Any, Any)*)(implicit format: Format) extends StringCommand {
     type Ret = Boolean
-    val line = multiBulk("MSETNX".getBytes("UTF-8") +: (kvs.foldRight(List[Any]()){ case ((k,v),l) => k :: v :: l }) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asBoolean
+    val line = multiBulk("MSETNX" +: (kvs.foldRight(List[Any]()){ case ((k,v),l) => k :: v :: l }) map format.apply)
+    val ret  = RedisReply(_: ByteString).asBoolean
   }
   
   case class SetRange(key: Any, offset: Int, value: Any)(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("SETRANGE".getBytes("UTF-8") +: (Seq(key, offset, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("SETRANGE" +: (Seq(key, offset, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
 
   case class GetRange[A](key: Any, start: Int, end: Int)(implicit format: Format, parse: Parse[A]) extends StringCommand {
     type Ret = Option[A]
-    val line = multiBulk("GETRANGE".getBytes("UTF-8") +: (Seq(key, start, end) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asBulk[A]
+    val line = multiBulk("GETRANGE" +: (Seq(key, start, end) map format.apply))
+    val ret  = RedisReply(_: ByteString).asBulk[A]
   }
   
   case class Strlen(key: Any)(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("STRLEN".getBytes("UTF-8") +: Seq(format.apply(key)))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("STRLEN" +: Seq(format.apply(key)))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class Append(key: Any, value: Any)(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("APPEND".getBytes("UTF-8") +: (Seq(key, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("APPEND" +: (Seq(key, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class GetBit(key: Any, offset: Int)(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("GETBIT".getBytes("UTF-8") +: (Seq(key, offset) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("GETBIT" +: (Seq(key, offset) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class SetBit(key: Any, offset: Int, value: Any)(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("SETBIT".getBytes("UTF-8") +: (Seq(key, offset, value) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("SETBIT" +: (Seq(key, offset, value) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class BitOp(op: String, destKey: Any, srcKeys: Any*)(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("BITOP".getBytes("UTF-8") +: ((op :: destKey :: srcKeys.toList) map format.apply))
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("BITOP" +: ((op :: destKey :: srcKeys.toList) map format.apply))
+    val ret  = RedisReply(_: ByteString).asLong
   }
   
   case class BitCount(key: Any, range: Option[(Int, Int)])(implicit format: Format) extends StringCommand {
     type Ret = Long
-    val line = multiBulk("BITCOUNT".getBytes("UTF-8") +: (List(key) ++ (range.map(_.productIterator.toList).getOrElse(List()))) map format.apply)
-    val ret  = RedisReply(_: Array[Byte]).asLong
+    val line = multiBulk("BITCOUNT" +: (List(key) ++ (range.map(_.productIterator.toList).getOrElse(List()))) map format.apply)
+    val ret  = RedisReply(_: ByteString).asLong
   }
 }
 


### PR DESCRIPTION
It might be too early optimization, but there's a lot of slicing/concatenation of byte array so I refactored them to use `akka.util.ByteString` which is designed for this purpose.

Also replaced `List` to `Vector` in reply parsing because appending to list is too expensive.
