### PR TITLE
Allow direct use of client actor

### DIFF
--- a/src/main/scala/com/redis/RedisClient.scala
+++ b/src/main/scala/com/redis/RedisClient.scala
@@ -25,7 +25,7 @@ object RedisClient {
   private val nameSeq = Iterator from 0
 }
 
-private class RedisClient(remote: InetSocketAddress, settings: RedisClientSettings) extends Actor with ActorLogging {
+class RedisClient(remote: InetSocketAddress, settings: RedisClientSettings) extends Actor with ActorLogging {
   import Tcp._
   import context.system
 


### PR DESCRIPTION
Sometimes it's nice to use the actor variant of the library instead of the future based API.
