### PR TITLE
ZRANK returns `Option[Long]` (fix #28)

### DIFF
--- a/src/main/scala/com/redis/protocol/SortedSetCommands.scala
+++ b/src/main/scala/com/redis/protocol/SortedSetCommands.scala
@@ -139,14 +139,14 @@ object SortedSetCommands {
 
 
   case class ZRank(key: String, member: Stringified)
-                   extends RedisCommand[Long] {
+      extends RedisCommand[Option[Long]]()(PartialDeserializer.liftOptionPD[Long]) {
     def line = multiBulk("ZRANK" +: key +: member.toString +: Nil)
 
     def reverse = ZRevRank(key, member)
   }
 
   case class ZRevRank(key: String, member: Stringified)
-    extends RedisCommand[Long] {
+      extends RedisCommand[Option[Long]]()(PartialDeserializer.liftOptionPD[Long]) {
     def line = multiBulk("ZREVRANK" +: key +: member.toString +: Nil)
   }
 

--- a/src/test/scala/com/redis/api/SortedSetOperationsSpec.scala
+++ b/src/test/scala/com/redis/api/SortedSetOperationsSpec.scala
@@ -48,8 +48,9 @@ class SortedSetOperationsSpec extends RedisSpecBase {
   describe("zrank") {
     it ("should give proper rank") {
       add
-      client.zrank("hackers", "yukihiro matsumoto").futureValue should equal (4)
-      client.zrevrank("hackers", "yukihiro matsumoto").futureValue should equal (1)
+      client.zrank("hackers", "yukihiro matsumoto").futureValue should equal (Some(4))
+      client.zrevrank("hackers", "yukihiro matsumoto").futureValue should equal (Some(1))
+      client.zrank("hackers", "michael jackson").futureValue should equal (None)
     }
   }
 


### PR DESCRIPTION
Added `liftOptionPD[A]` to wrap possible non-bulk replies with `Option`
