### PR TITLE
Refactor (de)serialization to support raw Bytes (fix #27)

### DIFF
--- a/src/main/scala/com/redis/api/EvalOperations.scala
+++ b/src/main/scala/com/redis/api/EvalOperations.scala
@@ -10,11 +10,11 @@ trait EvalOperations { this: RedisOps =>
   import EvalCommands._
 
   def eval[A](script: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-             (implicit timeout: Timeout, reader: Read[A]) =
+             (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(Eval[A](script, keys, args)).mapTo[Eval[A]#Ret]
 
   def evalsha[A](shaHash: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-                (implicit timeout: Timeout, reader: Read[A]) =
+                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(EvalSHA[A](shaHash, keys, args)).mapTo[EvalSHA[A]#Ret]
 
   // Sub-commands of SCRIPT

--- a/src/main/scala/com/redis/api/HashOperations.scala
+++ b/src/main/scala/com/redis/api/HashOperations.scala
@@ -15,13 +15,13 @@ trait HashOperations { this: RedisOps =>
   def hsetnx(key: String, field: String, value: Stringified)(implicit timeout: Timeout) =
     clientRef.ask(HSet(key, field, value, true)).mapTo[HSet#Ret]
 
-  def hget[A](key: String, field: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def hget[A](key: String, field: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HGet[A](key, field)).mapTo[HGet[A]#Ret]
 
   def hmset(key: String, mapLike: Iterable[KeyValuePair])(implicit timeout: Timeout) =
     clientRef.ask(HMSet(key, mapLike)).mapTo[HMSet#Ret]
 
-  def hmget[A](key: String, fields: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def hmget[A](key: String, fields: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HMGet[A](key, fields:_*)).mapTo[HMGet[A]#Ret]
 
   def hincrby(key: String, field: String, value: Int)(implicit timeout: Timeout) =
@@ -44,9 +44,9 @@ trait HashOperations { this: RedisOps =>
   def hkeys(key: String)(implicit timeout: Timeout) =
     clientRef.ask(HKeys(key)).mapTo[HKeys#Ret]
 
-  def hvals[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def hvals[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HVals(key)).mapTo[HVals[A]#Ret]
 
-  def hgetall[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def hgetall[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HGetall(key)).mapTo[HGetall[A]#Ret]
 }

--- a/src/main/scala/com/redis/api/KeyOperations.scala
+++ b/src/main/scala/com/redis/api/KeyOperations.scala
@@ -132,7 +132,7 @@ trait KeyOperations { this: RedisOps =>
     desc: Boolean = false, 
     alpha: Boolean = false, 
     by: Option[String] = None, 
-    get: Seq[String] = Nil)(implicit timeout: Timeout, reader: Read[A]) =
+    get: Seq[String] = Nil)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(Sort(key, limit, desc, alpha, by, get)).mapTo[Sort[A]#Ret]
 
   // SORT with STORE

--- a/src/main/scala/com/redis/api/ListOperations.scala
+++ b/src/main/scala/com/redis/api/ListOperations.scala
@@ -48,7 +48,7 @@ trait ListOperations { this: RedisOps =>
   // LRANGE
   // return the specified elements of the list stored at the specified key.
   // Start and end are zero-based indexes.
-  def lrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def lrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(LRange(key, start, end)).mapTo[LRange[A]#Ret]
 
   // LTRIM
@@ -59,7 +59,7 @@ trait ListOperations { this: RedisOps =>
   // LINDEX
   // return the especified element of the list stored at the specified key.
   // Negative indexes are supported, for example -1 is the last element, -2 the penultimate and so on.
-  def lindex[A](key: String, index: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def lindex[A](key: String, index: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(LIndex[A](key, index)).mapTo[LIndex[A]#Ret]
 
   // LSET
@@ -74,39 +74,39 @@ trait ListOperations { this: RedisOps =>
 
   // LPOP
   // atomically return and remove the first (LPOP) or last (RPOP) element of the list
-  def lpop[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def lpop[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(LPop[A](key)).mapTo[LPop[A]#Ret]
 
   // RPOP
   // atomically return and remove the first (LPOP) or last (RPOP) element of the list
-  def rpop[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def rpop[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(RPop[A](key)).mapTo[RPop[A]#Ret]
 
   // RPOPLPUSH
   // Remove the first count occurrences of the value element from the list.
   def rpoplpush[A](srcKey: String, dstKey: String)
-                  (implicit timeout: Timeout, reader: Read[A]) =
+                  (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(RPopLPush[A](srcKey, dstKey)).mapTo[RPopLPush[A]#Ret]
 
   def brpoplpush[A](srcKey: String, dstKey: String, timeoutInSeconds: Int)
-                   (implicit timeout: Timeout, reader: Read[A]) =
+                   (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BRPopLPush[A](srcKey, dstKey, timeoutInSeconds)).mapTo[BRPopLPush[A]#Ret]
 
 
   def blpop[A](timeoutInSeconds: Int, keys: Seq[String])
-              (implicit timeout: Timeout, reader: Read[A]) =
+              (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BLPop[A](timeoutInSeconds, keys)).mapTo[BLPop[A]#Ret]
 
   def blpop[A](timeoutInSeconds: Int, key: String, keys: String*)
-                (implicit timeout: Timeout, reader: Read[A]) =
+                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BLPop[A](timeoutInSeconds, key, keys:_*)).mapTo[BLPop[A]#Ret]
 
 
   def brpop[A](timeoutInSeconds: Int, keys: Seq[String])
-              (implicit timeout: Timeout, reader: Read[A]) =
+              (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BRPop[A](timeoutInSeconds, keys)).mapTo[BRPop[A]#Ret]
 
   def brpop[A](timeoutInSeconds: Int, key: String, keys: String*)
-                (implicit timeout: Timeout, reader: Read[A]) =
+                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BRPop[A](timeoutInSeconds, key, keys:_*)).mapTo[BRPop[A]#Ret]
 }

--- a/src/main/scala/com/redis/api/NodeOperations.scala
+++ b/src/main/scala/com/redis/api/NodeOperations.scala
@@ -66,7 +66,7 @@ trait NodeOperations { this: RedisOps =>
   object config {
     import Config._
 
-    def get[A](param: String)(implicit timeout: Timeout, reader: Read[A]) =
+    def get[A](param: String)(implicit timeout: Timeout, reader: Reader[A]) =
       clientRef.ask(Get(param)).mapTo[Get[A]#Ret]
 
     def set(param: String, value: Stringified)(implicit timeout: Timeout) =

--- a/src/main/scala/com/redis/api/SetOperations.scala
+++ b/src/main/scala/com/redis/api/SetOperations.scala
@@ -29,7 +29,7 @@ trait SetOperations { this: RedisOps =>
 
   // SPOP
   // Remove and return (pop) a random element from the Set value at key.
-  def spop[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def spop[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SPop[A](key)).mapTo[SPop[A]#Ret]
 
   // SMOVE
@@ -49,10 +49,10 @@ trait SetOperations { this: RedisOps =>
 
   // SINTER
   // Return the intersection between the Sets stored at key1, key2, ..., keyN.
-  def sinter[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def sinter[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SInter[A](keys)).mapTo[SInter[A]#Ret]
 
-  def sinter[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def sinter[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SInter[A](key, keys:_*)).mapTo[SInter[A]#Ret]
 
   // SINTERSTORE
@@ -69,10 +69,10 @@ trait SetOperations { this: RedisOps =>
 
   // SUNION
   // Return the union between the Sets stored at key1, key2, ..., keyN.
-  def sunion[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def sunion[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SUnion[A](keys)).mapTo[SUnion[A]#Ret]
 
-  def sunion[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def sunion[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SUnion[A](key, keys:_*)).mapTo[SUnion[A]#Ret]
 
 
@@ -90,10 +90,10 @@ trait SetOperations { this: RedisOps =>
 
   // SDIFF
   // Return the difference between the Set stored at key1 and all the Sets key2, ..., keyN.
-  def sdiff[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def sdiff[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SDiff(keys)).mapTo[SDiff[A]#Ret]
 
-  def sdiff[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def sdiff[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SDiff(key, keys:_*)).mapTo[SDiff[A]#Ret]
 
 
@@ -109,17 +109,17 @@ trait SetOperations { this: RedisOps =>
 
   // SMEMBERS
   // Return all the members of the Set value at key.
-  def smembers[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def smembers[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SMembers(key)).mapTo[SMembers[A]#Ret]
 
   // SRANDMEMBER
   // Return a random element from a Set
-  def srandmember[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def srandmember[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SRandMember(key)).mapTo[SRandMember[A]#Ret]
 
   // SRANDMEMBER
   // Return multiple random elements from a Set (since 2.6)
-  def srandmember[A](key: String, count: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def srandmember[A](key: String, count: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SRandMembers(key, count)).mapTo[SRandMembers[A]#Ret]
 }
 

--- a/src/main/scala/com/redis/api/SortedSetOperations.scala
+++ b/src/main/scala/com/redis/api/SortedSetOperations.scala
@@ -52,19 +52,19 @@ trait SortedSetOperations { this: RedisOps =>
   // ZRANGE
   //
   def zrange[A](key: String, start: Int = 0, end: Int = -1)
-               (implicit timeout: Timeout, reader: Read[A]) =
+               (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRange[A](key, start, end)).mapTo[ZRange[A]#Ret]
 
   def zrevrange[A](key: String, start: Int = 0, end: Int = -1)
-               (implicit timeout: Timeout, reader: Read[A]) =
+               (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRevRange[A](key, start, end)).mapTo[ZRevRange[A]#Ret]
 
   def zrangeWithScores[A](key: String, start: Int = 0, end: Int = -1)
-                        (implicit timeout: Timeout, reader: Read[A]) =
+                        (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRangeWithScores[A](key, start, end)).mapTo[ZRangeWithScores[A]#Ret]
 
   def zrevrangeWithScores[A](key: String, start: Int = 0, end: Int = -1)
-                          (implicit timeout: Timeout, reader: Read[A]) =
+                          (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRevRangeWithScores[A](key, start, end)).mapTo[ZRevRangeWithScores[A]#Ret]
 
   // ZRANGEBYSCORE
@@ -73,7 +73,7 @@ trait SortedSetOperations { this: RedisOps =>
                        min: Double = `-Inf`, minInclusive: Boolean = true,
                        max: Double = `+Inf`, maxInclusive: Boolean = true,
                        limit: Option[(Int, Int)] = None)
-                      (implicit timeout: Timeout, reader: Read[A]) =
+                      (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRangeByScore[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRangeByScore[A]#Ret]
@@ -82,7 +82,7 @@ trait SortedSetOperations { this: RedisOps =>
                           max: Double = `+Inf`, maxInclusive: Boolean = true,
                           min: Double = `-Inf`, minInclusive: Boolean = true,
                           limit: Option[(Int, Int)] = None)
-                         (implicit timeout: Timeout, reader: Read[A]) =
+                         (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRevRangeByScore[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRevRangeByScore[A]#Ret]
@@ -91,7 +91,7 @@ trait SortedSetOperations { this: RedisOps =>
                                  min: Double = `-Inf`, minInclusive: Boolean = true,
                                  max: Double = `+Inf`, maxInclusive: Boolean = true,
                                  limit: Option[(Int, Int)] = None)
-                                (implicit timeout: Timeout, reader: Read[A]) =
+                                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRangeByScoreWithScores[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRangeByScoreWithScores[A]#Ret]
@@ -100,7 +100,7 @@ trait SortedSetOperations { this: RedisOps =>
                                     max: Double = `+Inf`, maxInclusive: Boolean = true,
                                     min: Double = `-Inf`, minInclusive: Boolean = true,
                                     limit: Option[(Int, Int)] = None)
-                                   (implicit timeout: Timeout, reader: Read[A]) =
+                                   (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRevRangeByScoreWithScores[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRevRangeByScoreWithScores[A]#Ret]

--- a/src/main/scala/com/redis/api/StringOperations.scala
+++ b/src/main/scala/com/redis/api/StringOperations.scala
@@ -13,7 +13,7 @@ trait StringOperations { this: RedisOps =>
 
   // GET (key)
   // gets the value for the specified key.
-  def get[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def get[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(Get[A](key)).mapTo[Get[A]#Ret]
 
   // SET KEY (key, value)
@@ -32,7 +32,7 @@ trait StringOperations { this: RedisOps =>
 
   // GETSET (key, value)
   // is an atomic set this value and return the old value command.
-  def getset[A](key: String, value: Stringified)(implicit timeout: Timeout, reader: Read[A]) =
+  def getset[A](key: String, value: Stringified)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(GetSet[A](key, value)).mapTo[GetSet[A]#Ret]
 
   // SETNX (key, value)
@@ -73,10 +73,10 @@ trait StringOperations { this: RedisOps =>
 
   // MGET (key, key, key, ...)
   // get the values of all the specified keys.
-  def mget[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def mget[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(MGet[A](keys)).mapTo[MGet[A]#Ret]
 
-  def mget[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def mget[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(MGet[A](key, keys:_*)).mapTo[MGet[A]#Ret]
 
 
@@ -99,7 +99,7 @@ trait StringOperations { this: RedisOps =>
   // GETRANGE key start end
   // Returns the substring of the string value stored at key, determined by the offsets
   // start and end (both are inclusive).
-  def getrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def getrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(GetRange[A](key, start, end)).mapTo[GetRange[A]#Ret]
 
   // STRLEN key

--- a/src/main/scala/com/redis/protocol/EvalCommands.scala
+++ b/src/main/scala/com/redis/protocol/EvalCommands.scala
@@ -7,12 +7,12 @@ import RedisCommand._
 object EvalCommands {
 
   case class Eval[A](script: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-                        (implicit reader: Read[A]) extends RedisCommand[List[A]]()(PartialDeserializer.ensureListPD) {
+                        (implicit reader: Reader[A]) extends RedisCommand[List[A]]()(PartialDeserializer.ensureListPD) {
     def line = multiBulk("EVAL" +: argsForEval(script, keys, args))
   }
 
   case class EvalSHA[A](shaHash: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-                       (implicit reader: Read[A]) extends RedisCommand[List[A]]()(PartialDeserializer.ensureListPD) {
+                       (implicit reader: Reader[A]) extends RedisCommand[List[A]]()(PartialDeserializer.ensureListPD) {
     def line = multiBulk("EVALSHA" +: argsForEval(shaHash, keys, args))
   }
 
@@ -33,5 +33,5 @@ object EvalCommands {
   }
 
   private def argsForEval[A](luaCode: String, keys: Seq[String], args: Seq[Stringified]): Seq[String] =
-    luaCode +: keys.length.toString +: (keys ++ args.map(_.toString))
+    luaCode +: keys.length.toString +: (keys ++ args.map(_.value))
 }

--- a/src/main/scala/com/redis/protocol/HashCommands.scala
+++ b/src/main/scala/com/redis/protocol/HashCommands.scala
@@ -6,10 +6,10 @@ import RedisCommand._
 
 object HashCommands {
   case class HSet(key: String, field: String, value: Stringified, nx: Boolean = false) extends RedisCommand[Boolean] {
-    def line = multiBulk((if (nx) "HSETNX" else "HSET") +: Seq(key, field, value.toString))
+    def line = multiBulk((if (nx) "HSETNX" else "HSET") +: Seq(key, field, value.value))
   }
   
-  case class HGet[A](key: String, field: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+  case class HGet[A](key: String, field: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("HGET" +: Seq(key, field))
   }
   
@@ -17,7 +17,7 @@ object HashCommands {
     def line = multiBulk("HMSET" +: key +: flattenPairs(mapLike))
   }
   
-  case class HMGet[A](key: String, fields: String*)(implicit reader: Read[A])
+  case class HMGet[A](key: String, fields: String*)(implicit reader: Reader[A])
       extends RedisCommand[Map[String, A]]()(PartialDeserializer.keyedMapPD(fields)) {
     require(fields.nonEmpty)
     def line = multiBulk("HMGET" +: key +: fields)
@@ -50,11 +50,11 @@ object HashCommands {
     def line = multiBulk("HKEYS" +: Seq(key))
   }
   
-  case class HVals[A](key: String)(implicit reader: Read[A]) extends RedisCommand[List[A]] {
+  case class HVals[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[List[A]] {
     def line = multiBulk("HVALS" +: Seq(key))
   }
   
-  case class HGetall[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Map[String, A]] {
+  case class HGetall[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[Map[String, A]] {
     def line = multiBulk("HGETALL" +: Seq(key))
   }
 }

--- a/src/main/scala/com/redis/protocol/KeyCommands.scala
+++ b/src/main/scala/com/redis/protocol/KeyCommands.scala
@@ -1,6 +1,6 @@
 package com.redis.protocol
 
-import com.redis.serialization.{PartialDeserializer, Read}
+import com.redis.serialization.{PartialDeserializer, Reader}
 import RedisCommand._
 
 
@@ -77,7 +77,7 @@ object KeyCommands {
     desc: Boolean = false, 
     alpha: Boolean = false, 
     by: Option[String] = None, 
-    get: Seq[String] = Nil)(implicit reader: Read[A]) extends RedisCommand[List[A]] {
+    get: Seq[String] = Nil)(implicit reader: Reader[A]) extends RedisCommand[List[A]] {
 
     def line = multiBulk("SORT" +: makeSortArgs(key, limit, desc, alpha, by, get))
   }

--- a/src/main/scala/com/redis/protocol/ListCommands.scala
+++ b/src/main/scala/com/redis/protocol/ListCommands.scala
@@ -8,7 +8,7 @@ object ListCommands {
 
   case class LPush(key: String, values: Seq[Stringified]) extends RedisCommand[Long] {
     require(values.nonEmpty)
-    def line = multiBulk("LPUSH" +: key +: values.map(_.toString))
+    def line = multiBulk("LPUSH" +: key +: values.map(_.value))
   }
 
   object LPush {
@@ -17,13 +17,13 @@ object ListCommands {
 
 
   case class LPushX(key: String, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("LPUSHX" +: key +: value.toString +: Nil)
+    def line = multiBulk("LPUSHX" +: key +: value.value +: Nil)
   }
 
 
   case class RPush(key: String, values: Seq[Stringified]) extends RedisCommand[Long] {
     require(values.nonEmpty)
-    def line = multiBulk("RPUSH" +: key +: values.map(_.toString))
+    def line = multiBulk("RPUSH" +: key +: values.map(_.value))
   }
 
   object RPush {
@@ -32,11 +32,11 @@ object ListCommands {
 
 
   case class RPushX(key: String, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("RPUSHX" +: Seq(key, value.toString))
+    def line = multiBulk("RPUSHX" +: Seq(key, value.value))
   }
   
   case class LRange[A](key: String, start: Int, stop: Int)
-                      (implicit reader: Read[A]) extends RedisCommand[List[A]] {
+                      (implicit reader: Reader[A]) extends RedisCommand[List[A]] {
     def line = multiBulk("LRANGE" +: key +: Seq(start, stop).map(_.toString))
   }
 
@@ -48,63 +48,63 @@ object ListCommands {
     def line = multiBulk("LTRIM" +: key +: Seq(start, end).map(_.toString))
   }
   
-  case class LIndex[A](key: String, index: Int)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+  case class LIndex[A](key: String, index: Int)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("LINDEX" +: Seq(key, index.toString))
 
   }
 
   case class LSet(key: String, index: Int, value: Stringified) extends RedisCommand[Boolean] {
-    def line = multiBulk("LSET" +: Seq(key, index.toString, value.toString))
+    def line = multiBulk("LSET" +: Seq(key, index.toString, value.value))
 
   }
 
   case class LRem(key: String, count: Int, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("LREM" +: Seq(key, count.toString, value.toString))
+    def line = multiBulk("LREM" +: Seq(key, count.toString, value.value))
 
   }
   
-  case class LPop[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+  case class LPop[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("LPOP" +: Seq(key))
 
   }
   
-  case class RPop[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+  case class RPop[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("RPOP" +: Seq(key))
 
   }
   
   case class RPopLPush[A](srcKey: String, dstKey: String)
-                         (implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+                         (implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("RPOPLPUSH" +: Seq(srcKey, dstKey))
 
   }
   
   case class BRPopLPush[A](srcKey: String, dstKey: String, timeoutInSeconds: Int)
-                          (implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+                          (implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("BRPOPLPUSH" +: Seq(srcKey, dstKey, timeoutInSeconds.toString))
 
   }
   
   case class BLPop[A](timeoutInSeconds: Int, keys: Seq[String])
-                     (implicit reader: Read[A]) extends RedisCommand[Option[(String, A)]] {
+                     (implicit reader: Reader[A]) extends RedisCommand[Option[(String, A)]] {
     require(keys.nonEmpty)
     def line = multiBulk("BLPOP" +: keys.foldRight(timeoutInSeconds.toString :: Nil)(_ :: _))
   }
 
   object BLPop {
-    def apply[A](timeoutInSeconds: Int, key: String, keys: String*)(implicit reader: Read[A]): BLPop[A] =
+    def apply[A](timeoutInSeconds: Int, key: String, keys: String*)(implicit reader: Reader[A]): BLPop[A] =
       BLPop(timeoutInSeconds, key +: keys)
   }
 
   
   case class BRPop[A](timeoutInSeconds: Int, keys: Seq[String])
-                     (implicit reader: Read[A]) extends RedisCommand[Option[(String, A)]] {
+                     (implicit reader: Reader[A]) extends RedisCommand[Option[(String, A)]] {
     require(keys.nonEmpty)
     def line = multiBulk("BRPOP" +: keys.foldRight(timeoutInSeconds.toString :: Nil)(_ :: _))
   }
 
   object BRPop {
-    def apply[A](timeoutInSeconds: Int, key: String, keys: String*)(implicit reader: Read[A]): BRPop[A] =
+    def apply[A](timeoutInSeconds: Int, key: String, keys: String*)(implicit reader: Reader[A]): BRPop[A] =
       BRPop(timeoutInSeconds, key +: keys)
   }
 }

--- a/src/main/scala/com/redis/protocol/NodeCommands.scala
+++ b/src/main/scala/com/redis/protocol/NodeCommands.scala
@@ -63,12 +63,12 @@ object NodeCommands {
 
   object Config {
 
-    case class Get[A](globStyleParam: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+    case class Get[A](globStyleParam: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
       def line = multiBulk(Seq("CONFIG", "GET", globStyleParam))
     }
 
     case class Set(param: String, value: Stringified) extends RedisCommand[Boolean] {
-      def line = multiBulk("CONFIG" +: Seq("SET", param, value.toString))
+      def line = multiBulk("CONFIG" +: Seq("SET", param, value.value))
     }
 
     case object ResetStat extends RedisCommand[Boolean] {

--- a/src/main/scala/com/redis/protocol/RedisCommand.scala
+++ b/src/main/scala/com/redis/protocol/RedisCommand.scala
@@ -17,7 +17,7 @@ abstract class RedisCommand[A]()(implicit _des: PartialDeserializer[A]) {
 object RedisCommand {
 
   def flattenPairs(in: Iterable[KeyValuePair]) =
-    in.iterator.flatMap(x => Iterator(x.key, x.value.toString)).toList
+    in.iterator.flatMap(x => Iterator(x.key, x.value.value)).toList
   
   def multiBulk(args: Seq[String]): ByteString = {
     val b = new ByteStringBuilder

--- a/src/main/scala/com/redis/protocol/SetCommands.scala
+++ b/src/main/scala/com/redis/protocol/SetCommands.scala
@@ -8,7 +8,7 @@ object SetCommands {
 
   case class SAdd(key: String, values: Seq[Stringified]) extends RedisCommand[Long] {
     require(values.nonEmpty)
-    def line = multiBulk("SADD" +: key +: values.map(_.toString))
+    def line = multiBulk("SADD" +: key +: values.map(_.value))
   }
 
   object SAdd {
@@ -18,7 +18,7 @@ object SetCommands {
 
   case class SRem(key: String, values: Seq[Stringified]) extends RedisCommand[Long] {
     require(values.nonEmpty)
-    def line = multiBulk("SREM" +: key +: values.map(_.toString))
+    def line = multiBulk("SREM" +: key +: values.map(_.value))
   }
 
   object SRem {
@@ -26,12 +26,12 @@ object SetCommands {
   }
 
 
-  case class SPop[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+  case class SPop[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("SPOP" +: Seq(key))
   }
   
   case class SMove(srcKey: String, destKey: String, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("SMOVE" +: Seq(srcKey, destKey, value.toString))
+    def line = multiBulk("SMOVE" +: Seq(srcKey, destKey, value.value))
   }
 
   case class SCard(key: String) extends RedisCommand[Long] {
@@ -39,37 +39,37 @@ object SetCommands {
   }
 
   case class SIsMember(key: String, value: Stringified) extends RedisCommand[Boolean] {
-    def line = multiBulk("SISMEMBER" +: Seq(key, value.toString))
+    def line = multiBulk("SISMEMBER" +: Seq(key, value.value))
   }
 
 
-  case class SInter[A](keys: Seq[String])(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SInter[A](keys: Seq[String])(implicit reader: Reader[A]) extends RedisCommand[Set[A]] {
     require(keys.nonEmpty)
     def line = multiBulk("SINTER" +: keys)
   }
 
   object SInter {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): SInter[A] = SInter(key +: keys)
+    def apply[A](key: String, keys: String*)(implicit reader: Reader[A]): SInter[A] = SInter(key +: keys)
   }
 
   
-  case class SUnion[A](keys: Seq[String])(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SUnion[A](keys: Seq[String])(implicit reader: Reader[A]) extends RedisCommand[Set[A]] {
     require(keys.nonEmpty)
     def line = multiBulk("SUNION" +: keys)
   }
 
   object SUnion {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): SUnion[A] = SUnion(key +: keys)
+    def apply[A](key: String, keys: String*)(implicit reader: Reader[A]): SUnion[A] = SUnion(key +: keys)
   }
 
 
-  case class SDiff[A](keys: Seq[String])(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SDiff[A](keys: Seq[String])(implicit reader: Reader[A]) extends RedisCommand[Set[A]] {
     require(keys.nonEmpty)
     def line = multiBulk("SDIFF" +: keys)
   }
 
   object SDiff {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): SDiff[A] = SDiff(key +: keys)
+    def apply[A](key: String, keys: String*)(implicit reader: Reader[A]): SDiff[A] = SDiff(key +: keys)
   }
 
 
@@ -106,15 +106,15 @@ object SetCommands {
   }
 
 
-  case class SMembers[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SMembers[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[Set[A]] {
     def line = multiBulk("SMEMBERS" +: Seq(key))
   }
 
-  case class SRandMember[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
+  case class SRandMember[A](key: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]] {
     def line = multiBulk("SRANDMEMBER" +: Seq(key))
   }
 
-  case class SRandMembers[A](key: String, count: Int)(implicit reader: Read[A]) extends RedisCommand[List[A]] {
+  case class SRandMembers[A](key: String, count: Int)(implicit reader: Reader[A]) extends RedisCommand[List[A]] {
     def line = multiBulk("SRANDMEMBER" +: (Seq(key, count.toString)))
   }
 }

--- a/src/main/scala/com/redis/serialization/Format.scala
+++ b/src/main/scala/com/redis/serialization/Format.scala
@@ -5,36 +5,49 @@ import scala.language.implicitConversions
 
 
 @implicitNotFound(msg = "Cannot find implicit Read or Format type class for ${A}")
-trait Read[A] {
-  val forByteArray: Boolean = false
-
-  def read(in: String): A
+private[redis] trait Reader[A] {
+  def fromByteString(in: ByteString): A
 }
 
-trait LowPriorityDefaultReader {
-  implicit object byteArrayReader extends Read[Array[Byte]] {
-    override val forByteArray = true
+trait StringReader[A] extends Reader[A] {
+  def read(in: String): A
 
-    def read(in: String): Array[Byte] = throw new Error("Not intended to use directly")
+  def fromByteString(in: ByteString): A = read(in.utf8String)
+}
+
+private[redis] trait LowPriorityDefaultReader {
+  implicit object bypassingReader extends Reader[ByteString] {
+    def fromByteString(in: ByteString) = in
+  }
+
+  implicit object byteArrayReader extends Reader[Array[Byte]] {
+    def fromByteString(in: ByteString) = in.toArray[Byte]
   }
 }
 
-object Read extends LowPriorityDefaultReader {
-  def apply[A](f: String => A) = new Read[A] { def read(in: String) = f(in) }
+object Reader extends LowPriorityDefaultReader {
+  def apply[A](f: String => A) = new StringReader[A] { def read(in: String) = f(in) }
 
-  implicit def default: Read[String] = DefaultFormats.stringFormat
+  implicit def default: Reader[String] = DefaultFormats.stringFormat
 }
 
 
 @implicitNotFound(msg = "Cannot find implicit Write or Format type class for ${A}")
-trait Write[A] {
-  def write(in: A): String
+private[redis] trait Writer[A] {
+  private[redis] def toByteString(in: A): ByteString
 }
 
-object Write {
-  def apply[A](f: A => String) = new Write[A] { def write(in: A) = f(in) }
+trait StringWriter[A] extends Writer[A] {
+  def write(in: A): String
 
-  implicit def default: Write[String] = DefaultFormats.stringFormat
+  def toByteString(in: A): ByteString = ByteString(write(in))
+}
+
+
+object Writer {
+  def apply[A](f: A => String) = new StringWriter[A] { def write(in: A) = f(in) }
+
+  implicit def default: Writer[String] = DefaultFormats.stringFormat
 
   private[redis] object Internal {
     def formatBoolean(b: Boolean) = if (b) "1" else "0"
@@ -51,7 +64,8 @@ object Write {
 }
 
 
-trait Format[A] extends Read[A] with Write[A]
+
+trait Format[A] extends StringReader[A] with StringWriter[A]
 
 object Format {
 

--- a/src/main/scala/com/redis/serialization/Integration.scala
+++ b/src/main/scala/com/redis/serialization/Integration.scala
@@ -6,26 +6,26 @@ import scala.language.implicitConversions
 trait SprayJsonSupport {
   import spray.json._
 
-  implicit def sprayJsonReader[A](implicit reader: RootJsonReader[A]): Read[A] =
-    Read(s => reader.read(s.asJson))
+  implicit def sprayJsonReader[A](implicit reader: RootJsonReader[A]): Reader[A] =
+    Reader(s => reader.read(s.asJson))
 
-  implicit def sprayJsonWriter[A](implicit writer: RootJsonWriter[A]): Write[A] =
-    Write(writer.write(_).toString)
+  implicit def sprayJsonWriter[A](implicit writer: RootJsonWriter[A]): Writer[A] =
+    Writer(writer.write(_).toString)
 }
 
 object SprayJsonSupport extends SprayJsonSupport
 
 
 trait Json4sSupport {
-  import org.json4s._
+  import org.json4s.{Serialization, Formats}
 
   def Serialization: Serialization
 
-  implicit def json4sReader[A](implicit format: Formats, manifest: Manifest[A]): Read[A] =
-    Read(Serialization.read(_))
+  implicit def json4sReader[A](implicit format: Formats, manifest: Manifest[A]): Reader[A] =
+    Reader(Serialization.read(_))
 
-  implicit def json4sWriter[A <: AnyRef](implicit format: Formats): Write[A] =
-    Write(Serialization.write(_))
+  implicit def json4sWriter[A <: AnyRef](implicit format: Formats): Writer[A] =
+    Writer(Serialization.write(_))
 }
 
 trait Json4sNativeSupport extends Json4sSupport {
@@ -44,11 +44,11 @@ object Json4sJacksonSupport extends Json4sJacksonSupport
 trait LiftJsonSupport {
   import net.liftweb.json._
 
-  implicit def liftJsonReader[A](implicit format: Formats, manifest: Manifest[A]): Read[A] =
-    Read(parse(_).extract[A])
+  implicit def liftJsonReader[A](implicit format: Formats, manifest: Manifest[A]): Reader[A] =
+    Reader(parse(_).extract[A])
 
-  implicit def liftJsonWriter[A <: AnyRef](implicit format: Formats): Write[A] =
-    Write(Serialization.write(_))
+  implicit def liftJsonWriter[A <: AnyRef](implicit format: Formats): Writer[A] =
+    Writer(Serialization.write(_))
 }
 
 object LiftJsonSupport extends LiftJsonSupport

--- a/src/main/scala/com/redis/serialization/PartialDeserializer.scala
+++ b/src/main/scala/com/redis/serialization/PartialDeserializer.scala
@@ -25,12 +25,11 @@ object PartialDeserializer extends LowPriorityPD {
 
   import PrefixDeserializer._
 
-  implicit val intPD     = _intPD
-  implicit val longPD    = _longPD
-  implicit val rawBulkPD = _rawBulkPD
-  implicit val bulkPD    = _rawBulkPD andThen (_ map (new String(_, "UTF-8")))
-  implicit val booleanPD = _booleanPD
-  implicit val stringPD  = bulkPD.andThen {
+  implicit val intPD        = _intPD
+  implicit val longPD       = _longPD
+  implicit val bulkPD       = _rawBulkPD
+  implicit val booleanPD    = _booleanPD
+  implicit val byteStringPD = bulkPD.andThen {
     _.getOrElse { throw new Error("Non-empty bulk reply expected, but got nil") }
   } orElse _statusStringPD
 
@@ -43,33 +42,34 @@ object PartialDeserializer extends LowPriorityPD {
 private[serialization] trait LowPriorityPD extends CommandSpecificPD {
   import PartialDeserializer._
 
-  implicit def parsedPD[A](implicit reader: Read[A]): PartialDeserializer[A] =
-    stringPD andThen reader.read
+  implicit def parsedPD[A](implicit reader: Reader[A]): PartialDeserializer[A] =
+    byteStringPD andThen reader.fromByteString
 
-  implicit def parsedOptionPD[A](implicit reader: Read[A]): PartialDeserializer[Option[A]] =
-    if (reader.forByteArray)
-      rawBulkPD.asInstanceOf[PartialDeserializer[Option[A]]]
-    else
-      bulkPD andThen (_ map reader.read)
+  implicit def parsedOptionPD[A](implicit reader: Reader[A]): PartialDeserializer[Option[A]] =
+    bulkPD andThen (_ map reader.fromByteString)
 
-  implicit def setPD[A](implicit parse: Read[A]): PartialDeserializer[Set[A]] =
+  implicit def setPD[A](implicit parse: Reader[A]): PartialDeserializer[Set[A]] =
     multiBulkPD[A, Set]
 
-  implicit def pairOptionListPD[A, B](implicit parseA: Read[A], parseB: Read[B]): PartialDeserializer[List[Option[(A, B)]]] =
+  implicit def pairOptionListPD[A, B](implicit parseA: Reader[A], parseB: Reader[B]): PartialDeserializer[List[Option[(A, B)]]] =
     pairOptionIteratorPD[A, B] andThen (_.toList)
 
-  implicit def pairOptionPD[A, B](implicit parseA: Read[A], parseB: Read[B]): PartialDeserializer[Option[(A, B)]] =
+  implicit def pairOptionPD[A, B](implicit parseA: Reader[A], parseB: Reader[B]): PartialDeserializer[Option[(A, B)]] =
     pairOptionIteratorPD[A, B] andThen (_.next)
 
-  implicit def mapPD[K, V](implicit parseA: Read[K], parseB: Read[V]): PartialDeserializer[Map[K, V]] =
+  implicit def mapPD[K, V](implicit parseA: Reader[K], parseB: Reader[V]): PartialDeserializer[Map[K, V]] =
     pairIteratorPD[K, V] andThen (_.toMap)
 
-  protected def pairIteratorPD[A, B](implicit readA: Read[A], readB: Read[B]): PartialDeserializer[Iterator[(A, B)]] =
-    multiBulkPD[String, Iterable] andThen (_.grouped(2).map { case Seq(a, b) => (readA.read(a), readB.read(b)) })
+  protected def pairIteratorPD[A, B](implicit readA: Reader[A], readB: Reader[B]): PartialDeserializer[Iterator[(A, B)]] =
+    multiBulkPD[ByteString, Iterable] andThen {
+      _.grouped(2).map {
+        case Seq(a, b) => (readA.fromByteString(a), readB.fromByteString(b))
+      }
+    }
 
-  protected def pairOptionIteratorPD[A, B](implicit readA: Read[A], readB: Read[B]): PartialDeserializer[Iterator[Option[(A, B)]]] =
-    multiBulkPD[Option[String], Iterable] andThen (_.grouped(2).map {
-      case Seq(Some(a), Some(b)) => Some((readA.read(a), readB.read(b)))
+  protected def pairOptionIteratorPD[A, B](implicit readA: Reader[A], readB: Reader[B]): PartialDeserializer[Iterator[Option[(A, B)]]] =
+    multiBulkPD[Option[ByteString], Iterable] andThen (_.grouped(2).map {
+      case Seq(Some(a), Some(b)) => Some((readA.fromByteString(a), readB.fromByteString(b)))
       case _ => None
     })
 }
@@ -84,7 +84,7 @@ private[serialization] trait CommandSpecificPD { this: LowPriorityPD =>
   // special deserializers for Sorted Set
   implicit def doubleOptionPD: PartialDeserializer[Option[Double]] = parsedOptionPD[Double]
 
-  implicit def scoredListPD[A](implicit reader: Read[A]): PartialDeserializer[List[(A, Double)]] =
+  implicit def scoredListPD[A](implicit reader: Reader[A]): PartialDeserializer[List[(A, Double)]] =
     pairIteratorPD[A, Double] andThen (_.toList)
 
   // lift non-bulk reply to `Option`
@@ -93,10 +93,14 @@ private[serialization] trait CommandSpecificPD { this: LowPriorityPD =>
 
 
   // special deserializer for (H)MGET
-  def keyedMapPD[A](fields: Seq[String])(implicit reader: Read[A]): PartialDeserializer[Map[String, A]] =
-    multiBulkPD[Option[A], Iterable] andThen { _.view.zip(fields).collect { case (Some(value), field) => (field, value) }.toMap }
+  def keyedMapPD[A](fields: Seq[String])(implicit reader: Reader[A]): PartialDeserializer[Map[String, A]] =
+    multiBulkPD[Option[A], Iterable] andThen {
+      _.view.zip(fields).collect {
+        case (Some(value), field) => (field, value)
+      }.toMap
+    }
 
   // special deserializer for EVAL(SHA)
-  def ensureListPD[A](implicit reader: Read[A]): PartialDeserializer[List[A]] =
+  def ensureListPD[A](implicit reader: Reader[A]): PartialDeserializer[List[A]] =
     multiBulkPD[A, List].orElse(parsedOptionPD[A].andThen(_.toList))
 }

--- a/src/main/scala/com/redis/serialization/Stringified.scala
+++ b/src/main/scala/com/redis/serialization/Stringified.scala
@@ -3,12 +3,12 @@ package com.redis.serialization
 import scala.language.implicitConversions
 
 
-class Stringified(override val toString: String) extends AnyVal
+class Stringified(val value: String) extends AnyVal
 
 object Stringified {
-  implicit def apply[A](v: A)(implicit writer: Write[A]) = new Stringified(writer.write(v))
+  implicit def apply[A](v: A)(implicit writer: Writer[A]) = new Stringified(writer.toByteString(v).utf8String)
 
-  implicit def applySeq[A](vs: Seq[A])(implicit writer: Write[A]): Seq[Stringified] = vs.map(apply[A])
+  implicit def applySeq[A](vs: Seq[A])(implicit writer: Writer[A]): Seq[Stringified] = vs.map(apply[A])
 }
 
 
@@ -22,13 +22,13 @@ object KeyValuePair {
   implicit def apply(pair: Product2[String, Stringified]): KeyValuePair =
     new KeyValuePair(pair)
 
-  implicit def apply[A](pair: Product2[String, A])(implicit writer: Write[A]): KeyValuePair =
+  implicit def apply[A](pair: Product2[String, A])(implicit writer: Writer[A]): KeyValuePair =
     new KeyValuePair((pair._1, Stringified(pair._2)))
 
-  implicit def applySeq[A](pairs: Seq[Product2[String, A]])(implicit writer: Write[A]): Seq[KeyValuePair] =
+  implicit def applySeq[A](pairs: Seq[Product2[String, A]])(implicit writer: Writer[A]): Seq[KeyValuePair] =
     pairs.map(apply[A])
 
-  implicit def applyIterable[A](pairs: Iterable[Product2[String, A]])(implicit writer: Write[A]): Iterable[KeyValuePair] =
+  implicit def applyIterable[A](pairs: Iterable[Product2[String, A]])(implicit writer: Writer[A]): Iterable[KeyValuePair] =
     pairs.map(apply[A])
 
   def unapply(kvp: KeyValuePair) = Some(kvp.pair)
@@ -45,10 +45,10 @@ object ScoredValue {
   implicit def apply(pair: Product2[Double, Stringified]): ScoredValue =
     new ScoredValue(pair)
 
-  implicit def apply[A, B](pair: Product2[A, B])(implicit num: Numeric[A], writer: Write[B]): ScoredValue =
+  implicit def apply[A, B](pair: Product2[A, B])(implicit num: Numeric[A], writer: Writer[B]): ScoredValue =
     new ScoredValue((num.toDouble(pair._1), Stringified(pair._2)))
 
-  implicit def applySeq[A, B](pairs: Seq[Product2[A, B]])(implicit num: Numeric[A], writer: Write[B]): Seq[ScoredValue] =
+  implicit def applySeq[A, B](pairs: Seq[Product2[A, B]])(implicit num: Numeric[A], writer: Writer[B]): Seq[ScoredValue] =
     pairs.map(apply[A, B])
 
   def unapply(sv: ScoredValue) = Some(sv.pair)

--- a/src/main/scala/com/redis/serialization/package.scala
+++ b/src/main/scala/com/redis/serialization/package.scala
@@ -1,0 +1,10 @@
+package com.redis
+
+
+package object serialization {
+
+  //  Type alias to avoid importing it in every file
+  type ByteString = akka.util.ByteString
+  val ByteString = akka.util.ByteString
+
+}

--- a/src/test/scala/com/redis/api/StringOperationsSpec.scala
+++ b/src/test/scala/com/redis/api/StringOperationsSpec.scala
@@ -118,7 +118,7 @@ class StringOperationsSpec extends RedisSpecBase {
     }
   }
 
-  describe("BITOP") {
+  describe("bitop") {
     it("should perform bitwise operations") {
       val _ = Future.sequence(
         client.set("key1", "abc") ::

--- a/src/test/scala/com/redis/serialization/SerializationSpec.scala
+++ b/src/test/scala/com/redis/serialization/SerializationSpec.scala
@@ -37,8 +37,8 @@ class SerializationSpec extends FunSpec with Matchers  {
           }
         }
 
-      val write = implicitly[Write[Person]].write _
-      val read = implicitly[Read[Person]].read _
+      val write = implicitly[Writer[Person]].toByteString _
+      val read = implicitly[Reader[Person]].fromByteString _
 
       read(write(debasish)) should equal (debasish)
     }
@@ -59,7 +59,7 @@ class SerializationSpec extends FunSpec with Matchers  {
     it("should prioritize closer implicits") {
       @volatile var localWriterUsed = false
 
-      implicit val localWriter: Write[String] = Write { string =>
+      implicit val localWriter: Writer[String] = Writer { string =>
         localWriterUsed = true
         string
       }
@@ -79,11 +79,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val personFormat = jsonFormat2(Person)
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)
@@ -96,11 +96,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val format = org.json4s.DefaultFormats
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)
@@ -113,11 +113,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val format = org.json4s.DefaultFormats
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)
@@ -130,11 +130,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val format = net.liftweb.json.DefaultFormats
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)


### PR DESCRIPTION
New design draft to solve this.

General:
- [x] Rename Read/Write to parameterized Reader/Writer and make them private[redis]
- [x] ByteStringReader/Writer for Array[Byte] and ByteString
- ~~Delegation to another reader/writer (optional)~~
- ~~StringReader/Writer in conjunction with ByteStringReader/Writer~~
- [x] trait Format[A] extends StringReader[A] with StringWriter[A]

Command-side:
- [ ] Change Stringified to Serialized and wrap ByteString instead of String
  - It's a bit sad to lose extends AnyVal.. extending ByteString might work though
  - Type alias is not enough because we need a companion object for implicit conversion without import tax.
- [ ] Refactor command serialization logic to deal with ByteString earlier
