### PR TITLE
Refactor (de)serialization to support raw Bytes (fix #27)

### DIFF
--- a/src/main/scala/com/redis/api/EvalOperations.scala
+++ b/src/main/scala/com/redis/api/EvalOperations.scala
@@ -10,11 +10,11 @@ trait EvalOperations { this: RedisOps =>
   import EvalCommands._
 
   def eval[A](script: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-             (implicit timeout: Timeout, reader: Read[A]) =
+             (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(Eval[A](script, keys, args)).mapTo[Eval[A]#Ret]
 
   def evalsha[A](shaHash: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-                (implicit timeout: Timeout, reader: Read[A]) =
+                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(EvalSHA[A](shaHash, keys, args)).mapTo[EvalSHA[A]#Ret]
 
   // Sub-commands of SCRIPT

--- a/src/main/scala/com/redis/api/HashOperations.scala
+++ b/src/main/scala/com/redis/api/HashOperations.scala
@@ -13,16 +13,21 @@ trait HashOperations { this: RedisOps =>
     clientRef.ask(HSet(key, field, value)).mapTo[HSet#Ret]
 
   def hsetnx(key: String, field: String, value: Stringified)(implicit timeout: Timeout) =
-    clientRef.ask(HSet(key, field, value, true)).mapTo[HSet#Ret]
+    clientRef.ask(HSetNx(key, field, value)).mapTo[HSetNx#Ret]
 
-  def hget[A](key: String, field: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def hget[A](key: String, field: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HGet[A](key, field)).mapTo[HGet[A]#Ret]
 
   def hmset(key: String, mapLike: Iterable[KeyValuePair])(implicit timeout: Timeout) =
     clientRef.ask(HMSet(key, mapLike)).mapTo[HMSet#Ret]
 
-  def hmget[A](key: String, fields: String*)(implicit timeout: Timeout, reader: Read[A]) =
-    clientRef.ask(HMGet[A](key, fields:_*)).mapTo[HMGet[A]#Ret]
+
+  def hmget[A](key: String, fields: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
+    clientRef.ask(HMGet[A](key, fields)).mapTo[HMGet[A]#Ret]
+
+  def hmget[A](key: String, field: String, fields: String*)(implicit timeout: Timeout, reader: Reader[A]) =
+    clientRef.ask(HMGet[A](key, field, fields:_*)).mapTo[HMGet[A]#Ret]
+
 
   def hincrby(key: String, field: String, value: Int)(implicit timeout: Timeout) =
     clientRef.ask(HIncrby(key, field, value)).mapTo[HIncrby#Ret]
@@ -44,9 +49,9 @@ trait HashOperations { this: RedisOps =>
   def hkeys(key: String)(implicit timeout: Timeout) =
     clientRef.ask(HKeys(key)).mapTo[HKeys#Ret]
 
-  def hvals[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def hvals[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HVals(key)).mapTo[HVals[A]#Ret]
 
-  def hgetall[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def hgetall[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(HGetall(key)).mapTo[HGetall[A]#Ret]
 }

--- a/src/main/scala/com/redis/api/KeyOperations.scala
+++ b/src/main/scala/com/redis/api/KeyOperations.scala
@@ -32,7 +32,7 @@ trait KeyOperations { this: RedisOps =>
   // RENAMENX (oldkey, newkey)
   // rename oldkey into newkey but fails if the destination key newkey already exists.
   def renamenx(oldkey: String, newkey: String)(implicit timeout: Timeout) =
-    clientRef.ask(Rename(oldkey, newkey, nx = true)).mapTo[Rename#Ret]
+    clientRef.ask(RenameNx(oldkey, newkey)).mapTo[RenameNx#Ret]
 
   // DBSIZE
   // return the size of the db.
@@ -70,7 +70,7 @@ trait KeyOperations { this: RedisOps =>
   // PEXPIRE (key, expiry)
   // sets the expire time (in milli sec.) for the specified key.
   def pexpire(key: String, ttlInMillis: Int)(implicit timeout: Timeout) =
-    clientRef.ask(Expire(key, ttlInMillis, millis = true)).mapTo[Expire#Ret]
+    clientRef.ask(PExpire(key, ttlInMillis)).mapTo[PExpire#Ret]
 
   // EXPIREAT (key, unix timestamp)
   // sets the expire time for the specified key.
@@ -80,7 +80,7 @@ trait KeyOperations { this: RedisOps =>
   // PEXPIREAT (key, unix timestamp)
   // sets the expire timestamp in millis for the specified key.
   def pexpireat(key: String, timestampInMillis: Long)(implicit timeout: Timeout) =
-    clientRef.ask(ExpireAt(key, timestampInMillis, millis = true)).mapTo[ExpireAt#Ret]
+    clientRef.ask(PExpireAt(key, timestampInMillis)).mapTo[PExpireAt#Ret]
 
   // TTL (key)
   // returns the remaining time to live of a key that has a timeout
@@ -90,17 +90,17 @@ trait KeyOperations { this: RedisOps =>
   // PTTL (key)
   // returns the remaining time to live of a key that has a timeout in millis
   def pttl(key: String)(implicit timeout: Timeout) =
-    clientRef.ask(TTL(key, millis = true)).mapTo[TTL#Ret]
+    clientRef.ask(PTTL(key)).mapTo[PTTL#Ret]
 
   // FLUSHDB the DB
   // removes all the DB data.
   def flushdb()(implicit timeout: Timeout) =
-    clientRef.ask(FlushDB(all = false)).mapTo[FlushDB#Ret]
+    clientRef.ask(FlushDB).mapTo[FlushDB.Ret]
 
   // FLUSHALL the DB's
   // removes data from all the DB's.
   def flushall()(implicit timeout: Timeout) =
-    clientRef.ask(FlushDB(all = true)).mapTo[FlushDB#Ret]
+    clientRef.ask(FlushAll).mapTo[FlushAll.Ret]
 
   // MOVE
   // Move the specified key from the currently selected DB to the specified destination DB.
@@ -132,7 +132,7 @@ trait KeyOperations { this: RedisOps =>
     desc: Boolean = false, 
     alpha: Boolean = false, 
     by: Option[String] = None, 
-    get: Seq[String] = Nil)(implicit timeout: Timeout, reader: Read[A]) =
+    get: Seq[String] = Nil)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(Sort(key, limit, desc, alpha, by, get)).mapTo[Sort[A]#Ret]
 
   // SORT with STORE

--- a/src/main/scala/com/redis/api/ListOperations.scala
+++ b/src/main/scala/com/redis/api/ListOperations.scala
@@ -48,7 +48,7 @@ trait ListOperations { this: RedisOps =>
   // LRANGE
   // return the specified elements of the list stored at the specified key.
   // Start and end are zero-based indexes.
-  def lrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def lrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(LRange(key, start, end)).mapTo[LRange[A]#Ret]
 
   // LTRIM
@@ -59,7 +59,7 @@ trait ListOperations { this: RedisOps =>
   // LINDEX
   // return the especified element of the list stored at the specified key.
   // Negative indexes are supported, for example -1 is the last element, -2 the penultimate and so on.
-  def lindex[A](key: String, index: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def lindex[A](key: String, index: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(LIndex[A](key, index)).mapTo[LIndex[A]#Ret]
 
   // LSET
@@ -74,39 +74,39 @@ trait ListOperations { this: RedisOps =>
 
   // LPOP
   // atomically return and remove the first (LPOP) or last (RPOP) element of the list
-  def lpop[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def lpop[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(LPop[A](key)).mapTo[LPop[A]#Ret]
 
   // RPOP
   // atomically return and remove the first (LPOP) or last (RPOP) element of the list
-  def rpop[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def rpop[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(RPop[A](key)).mapTo[RPop[A]#Ret]
 
   // RPOPLPUSH
   // Remove the first count occurrences of the value element from the list.
   def rpoplpush[A](srcKey: String, dstKey: String)
-                  (implicit timeout: Timeout, reader: Read[A]) =
+                  (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(RPopLPush[A](srcKey, dstKey)).mapTo[RPopLPush[A]#Ret]
 
   def brpoplpush[A](srcKey: String, dstKey: String, timeoutInSeconds: Int)
-                   (implicit timeout: Timeout, reader: Read[A]) =
+                   (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BRPopLPush[A](srcKey, dstKey, timeoutInSeconds)).mapTo[BRPopLPush[A]#Ret]
 
 
   def blpop[A](timeoutInSeconds: Int, keys: Seq[String])
-              (implicit timeout: Timeout, reader: Read[A]) =
+              (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BLPop[A](timeoutInSeconds, keys)).mapTo[BLPop[A]#Ret]
 
   def blpop[A](timeoutInSeconds: Int, key: String, keys: String*)
-                (implicit timeout: Timeout, reader: Read[A]) =
+                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BLPop[A](timeoutInSeconds, key, keys:_*)).mapTo[BLPop[A]#Ret]
 
 
   def brpop[A](timeoutInSeconds: Int, keys: Seq[String])
-              (implicit timeout: Timeout, reader: Read[A]) =
+              (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BRPop[A](timeoutInSeconds, keys)).mapTo[BRPop[A]#Ret]
 
   def brpop[A](timeoutInSeconds: Int, key: String, keys: String*)
-                (implicit timeout: Timeout, reader: Read[A]) =
+                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(BRPop[A](timeoutInSeconds, key, keys:_*)).mapTo[BRPop[A]#Ret]
 }

--- a/src/main/scala/com/redis/api/NodeOperations.scala
+++ b/src/main/scala/com/redis/api/NodeOperations.scala
@@ -12,12 +12,12 @@ trait NodeOperations { this: RedisOps =>
   // SAVE
   // save the DB on disk now.
   def save()(implicit timeout: Timeout) =
-    clientRef.ask(Save).mapTo[Save#Ret]
+    clientRef.ask(Save).mapTo[Save.Ret]
 
   // BGSAVE
   // save the DB in the background.
   def bgsave()(implicit timeout: Timeout) =
-    clientRef.ask(Save(true)).mapTo[Save#Ret]
+    clientRef.ask(BgSave).mapTo[BgSave.Ret]
 
   // LASTSAVE
   // return the UNIX TIME of the last DB SAVE executed with success.
@@ -66,7 +66,7 @@ trait NodeOperations { this: RedisOps =>
   object config {
     import Config._
 
-    def get[A](param: String)(implicit timeout: Timeout, reader: Read[A]) =
+    def get[A](param: String)(implicit timeout: Timeout, reader: Reader[A]) =
       clientRef.ask(Get(param)).mapTo[Get[A]#Ret]
 
     def set(param: String, value: Stringified)(implicit timeout: Timeout) =

--- a/src/main/scala/com/redis/api/SetOperations.scala
+++ b/src/main/scala/com/redis/api/SetOperations.scala
@@ -29,7 +29,7 @@ trait SetOperations { this: RedisOps =>
 
   // SPOP
   // Remove and return (pop) a random element from the Set value at key.
-  def spop[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def spop[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SPop[A](key)).mapTo[SPop[A]#Ret]
 
   // SMOVE
@@ -49,10 +49,10 @@ trait SetOperations { this: RedisOps =>
 
   // SINTER
   // Return the intersection between the Sets stored at key1, key2, ..., keyN.
-  def sinter[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def sinter[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SInter[A](keys)).mapTo[SInter[A]#Ret]
 
-  def sinter[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def sinter[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SInter[A](key, keys:_*)).mapTo[SInter[A]#Ret]
 
   // SINTERSTORE
@@ -69,10 +69,10 @@ trait SetOperations { this: RedisOps =>
 
   // SUNION
   // Return the union between the Sets stored at key1, key2, ..., keyN.
-  def sunion[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def sunion[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SUnion[A](keys)).mapTo[SUnion[A]#Ret]
 
-  def sunion[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def sunion[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SUnion[A](key, keys:_*)).mapTo[SUnion[A]#Ret]
 
 
@@ -90,10 +90,10 @@ trait SetOperations { this: RedisOps =>
 
   // SDIFF
   // Return the difference between the Set stored at key1 and all the Sets key2, ..., keyN.
-  def sdiff[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def sdiff[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SDiff(keys)).mapTo[SDiff[A]#Ret]
 
-  def sdiff[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def sdiff[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SDiff(key, keys:_*)).mapTo[SDiff[A]#Ret]
 
 
@@ -109,17 +109,17 @@ trait SetOperations { this: RedisOps =>
 
   // SMEMBERS
   // Return all the members of the Set value at key.
-  def smembers[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def smembers[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SMembers(key)).mapTo[SMembers[A]#Ret]
 
   // SRANDMEMBER
   // Return a random element from a Set
-  def srandmember[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def srandmember[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SRandMember(key)).mapTo[SRandMember[A]#Ret]
 
   // SRANDMEMBER
   // Return multiple random elements from a Set (since 2.6)
-  def srandmember[A](key: String, count: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def srandmember[A](key: String, count: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(SRandMembers(key, count)).mapTo[SRandMembers[A]#Ret]
 }
 

--- a/src/main/scala/com/redis/api/SortedSetOperations.scala
+++ b/src/main/scala/com/redis/api/SortedSetOperations.scala
@@ -52,19 +52,19 @@ trait SortedSetOperations { this: RedisOps =>
   // ZRANGE
   //
   def zrange[A](key: String, start: Int = 0, end: Int = -1)
-               (implicit timeout: Timeout, reader: Read[A]) =
+               (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRange[A](key, start, end)).mapTo[ZRange[A]#Ret]
 
   def zrevrange[A](key: String, start: Int = 0, end: Int = -1)
-               (implicit timeout: Timeout, reader: Read[A]) =
+               (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRevRange[A](key, start, end)).mapTo[ZRevRange[A]#Ret]
 
   def zrangeWithScores[A](key: String, start: Int = 0, end: Int = -1)
-                        (implicit timeout: Timeout, reader: Read[A]) =
+                        (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRangeWithScores[A](key, start, end)).mapTo[ZRangeWithScores[A]#Ret]
 
   def zrevrangeWithScores[A](key: String, start: Int = 0, end: Int = -1)
-                          (implicit timeout: Timeout, reader: Read[A]) =
+                          (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(ZRevRangeWithScores[A](key, start, end)).mapTo[ZRevRangeWithScores[A]#Ret]
 
   // ZRANGEBYSCORE
@@ -73,7 +73,7 @@ trait SortedSetOperations { this: RedisOps =>
                        min: Double = `-Inf`, minInclusive: Boolean = true,
                        max: Double = `+Inf`, maxInclusive: Boolean = true,
                        limit: Option[(Int, Int)] = None)
-                      (implicit timeout: Timeout, reader: Read[A]) =
+                      (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRangeByScore[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRangeByScore[A]#Ret]
@@ -82,7 +82,7 @@ trait SortedSetOperations { this: RedisOps =>
                           max: Double = `+Inf`, maxInclusive: Boolean = true,
                           min: Double = `-Inf`, minInclusive: Boolean = true,
                           limit: Option[(Int, Int)] = None)
-                         (implicit timeout: Timeout, reader: Read[A]) =
+                         (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRevRangeByScore[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRevRangeByScore[A]#Ret]
@@ -91,7 +91,7 @@ trait SortedSetOperations { this: RedisOps =>
                                  min: Double = `-Inf`, minInclusive: Boolean = true,
                                  max: Double = `+Inf`, maxInclusive: Boolean = true,
                                  limit: Option[(Int, Int)] = None)
-                                (implicit timeout: Timeout, reader: Read[A]) =
+                                (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRangeByScoreWithScores[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRangeByScoreWithScores[A]#Ret]
@@ -100,7 +100,7 @@ trait SortedSetOperations { this: RedisOps =>
                                     max: Double = `+Inf`, maxInclusive: Boolean = true,
                                     min: Double = `-Inf`, minInclusive: Boolean = true,
                                     limit: Option[(Int, Int)] = None)
-                                   (implicit timeout: Timeout, reader: Read[A]) =
+                                   (implicit timeout: Timeout, reader: Reader[A]) =
     clientRef
       .ask(ZRevRangeByScoreWithScores[A](key, min, minInclusive, max, maxInclusive, limit))
       .mapTo[ZRevRangeByScoreWithScores[A]#Ret]

--- a/src/main/scala/com/redis/api/StringOperations.scala
+++ b/src/main/scala/com/redis/api/StringOperations.scala
@@ -13,7 +13,7 @@ trait StringOperations { this: RedisOps =>
 
   // GET (key)
   // gets the value for the specified key.
-  def get[A](key: String)(implicit timeout: Timeout, reader: Read[A]) =
+  def get[A](key: String)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(Get[A](key)).mapTo[Get[A]#Ret]
 
   // SET KEY (key, value)
@@ -32,7 +32,7 @@ trait StringOperations { this: RedisOps =>
 
   // GETSET (key, value)
   // is an atomic set this value and return the old value command.
-  def getset[A](key: String, value: Stringified)(implicit timeout: Timeout, reader: Read[A]) =
+  def getset[A](key: String, value: Stringified)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(GetSet[A](key, value)).mapTo[GetSet[A]#Ret]
 
   // SETNX (key, value)
@@ -73,10 +73,10 @@ trait StringOperations { this: RedisOps =>
 
   // MGET (key, key, key, ...)
   // get the values of all the specified keys.
-  def mget[A](keys: Seq[String])(implicit timeout: Timeout, reader: Read[A]) =
+  def mget[A](keys: Seq[String])(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(MGet[A](keys)).mapTo[MGet[A]#Ret]
 
-  def mget[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Read[A]) =
+  def mget[A](key: String, keys: String*)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(MGet[A](key, keys:_*)).mapTo[MGet[A]#Ret]
 
 
@@ -99,7 +99,7 @@ trait StringOperations { this: RedisOps =>
   // GETRANGE key start end
   // Returns the substring of the string value stored at key, determined by the offsets
   // start and end (both are inclusive).
-  def getrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Read[A]) =
+  def getrange[A](key: String, start: Int, end: Int)(implicit timeout: Timeout, reader: Reader[A]) =
     clientRef.ask(GetRange[A](key, start, end)).mapTo[GetRange[A]#Ret]
 
   // STRLEN key
@@ -124,8 +124,11 @@ trait StringOperations { this: RedisOps =>
 
   // BITOP op destKey srcKey...
   // Perform a bitwise operation between multiple keys (containing string values) and store the result in the destination key.
-  def bitop(op: String, destKey: String, srcKeys: String*)(implicit timeout: Timeout) =
-    clientRef.ask(BitOp(op, destKey, srcKeys:_*)).mapTo[BitOp#Ret]
+  def bitop(op: String, destKey: String, srcKeys: Seq[String])(implicit timeout: Timeout) =
+    clientRef.ask(BitOp(op, destKey, srcKeys)).mapTo[BitOp#Ret]
+
+  def bitop(op: String, destKey: String, srcKey: String, srcKeys: String*)(implicit timeout: Timeout) =
+    clientRef.ask(BitOp(op, destKey, srcKey, srcKeys: _*)).mapTo[BitOp#Ret]
 
   // BITCOUNT key range
   // Count the number of set bits in the given key within the optional range

--- a/src/main/scala/com/redis/pipeline/ResponseHandling.scala
+++ b/src/main/scala/com/redis/pipeline/ResponseHandling.scala
@@ -43,7 +43,8 @@ class ResponseHandling extends PipelineStage[WithinActorContext, Command, Comman
             case Result.NeedMoreData => ctx.singleEvent(RequestQueueEmpty)
 
             case Result.Failed(err, data) =>
-              log.error(err, "Failed to parse response: {}", data.utf8String.replace("\r\n", "\\r\\n"))
+              log.error(err, "Response parsing failed: {}", data.utf8String.replace("\r\n", "\\r\\n"))
+              commander.tell(Failure(err), redisClientRef)
               ctx.singleCommand(Close)
           }
         }

--- a/src/main/scala/com/redis/protocol/EvalCommands.scala
+++ b/src/main/scala/com/redis/protocol/EvalCommands.scala
@@ -1,37 +1,39 @@
 package com.redis.protocol
 
 import com.redis.serialization._
-import RedisCommand._
 
 
 object EvalCommands {
+  import DefaultWriters._
 
-  case class Eval[A](script: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-                        (implicit reader: Read[A]) extends RedisCommand[List[A]]()(PartialDeserializer.ensureListPD) {
-    def line = multiBulk("EVAL" +: argsForEval(script, keys, args))
+  case class Eval[A: Reader](script: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
+      extends RedisCommand[List[A]]("EVAL")(PartialDeserializer.ensureListPD) {
+
+    def params = argsForEval(script, keys, args)
   }
 
-  case class EvalSHA[A](shaHash: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
-                       (implicit reader: Read[A]) extends RedisCommand[List[A]]()(PartialDeserializer.ensureListPD) {
-    def line = multiBulk("EVALSHA" +: argsForEval(shaHash, keys, args))
+  case class EvalSHA[A: Reader](shaHash: String, keys: Seq[String] = Nil, args: Seq[Stringified] = Nil)
+      extends RedisCommand[List[A]]("EVALSHA")(PartialDeserializer.ensureListPD) {
+
+    def params = argsForEval(shaHash, keys, args)
   }
 
   object Script {
 
-    case class Load(script: String) extends RedisCommand[Option[String]] {
-      def line = multiBulk("SCRIPT" +: Seq("LOAD", script))
+    case class Load(script: String) extends RedisCommand[Option[String]]("SCRIPT") {
+      def params = "LOAD" +: script +: ANil
     }
 
-    case class Exists(shaHash: String) extends RedisCommand[List[Int]] {
-      def line = multiBulk("SCRIPT" +: Seq("EXISTS", shaHash))
+    case class Exists(shaHash: String) extends RedisCommand[List[Int]]("SCRIPT") {
+      def params = "EXISTS" +: shaHash +: ANil
     }
 
-    case object Flush extends RedisCommand[Boolean] {
-      def line = multiBulk("SCRIPT" +: Seq("FLUSH"))
+    case object Flush extends RedisCommand[Boolean]("SCRIPT") {
+      def params = "Flush" +: ANil
     }
 
   }
 
-  private def argsForEval[A](luaCode: String, keys: Seq[String], args: Seq[Stringified]): Seq[String] =
-    luaCode +: keys.length.toString +: (keys ++ args.map(_.toString))
+  private def argsForEval[A](luaCode: String, keys: Seq[String], args: Seq[Stringified]): Args =
+    luaCode +: keys.length +: keys ++: args.toArgs
 }

--- a/src/main/scala/com/redis/protocol/NodeCommands.scala
+++ b/src/main/scala/com/redis/protocol/NodeCommands.scala
@@ -1,61 +1,63 @@
 package com.redis.protocol
 
 import com.redis.serialization._
-import RedisCommand._
 
 
 object NodeCommands {
+  import DefaultWriters._
 
-  case class Save(bg: Boolean = false) extends RedisCommand[Boolean] {
-    def line = multiBulk(Seq((if (bg) "BGSAVE" else "SAVE")))
+  case object Save extends RedisCommand[Boolean]("SAVE") {
+    def params = ANil
   }
 
-  case object LastSave extends RedisCommand[Long] {
-    def line = multiBulk(Seq("LASTSAVE"))
+  case object BgSave extends RedisCommand[Boolean]("BGSAVE") {
+    def params = ANil
   }
 
-  case object Shutdown extends RedisCommand[Boolean] {
-    def line = multiBulk(Seq("SHUTDOWN"))
+  case object LastSave extends RedisCommand[Long]("LASTSAVE") {
+    def params = ANil
   }
 
-  case object BGRewriteAOF extends RedisCommand[Boolean] {
-    def line = multiBulk(Seq("BGREWRITEAOF"))
+  case object Shutdown extends RedisCommand[Boolean]("SHUTDOWN") {
+    def params = ANil
   }
 
-  case class Info(section: String) extends RedisCommand[Option[String]] {
-    def line = multiBulk(Seq("INFO", section))
+  case object BGRewriteAOF extends RedisCommand[Boolean]("BGREWRITEAOF") {
+    def params = ANil
   }
 
-  case object Monitor extends RedisCommand[Boolean] {
-    def line = multiBulk(Seq("MONITOR"))
+  case class Info(section: String) extends RedisCommand[Option[String]]("INFO") {
+    def params = section +: ANil
   }
 
-  case class SlaveOf(node: Option[(String, Int)]) extends RedisCommand[Boolean] {
-    def line = multiBulk(
-      node match {
-        case Some((h: String, p: Int)) => "SLAVEOF" +: Seq(h, p.toString)
-        case _ => Seq("SLAVEOF", "NO", "ONE")
-      }
-    )
+  case object Monitor extends RedisCommand[Boolean]("MONITOR") {
+    def params = ANil
+  }
+
+  case class SlaveOf(node: Option[(String, Int)]) extends RedisCommand[Boolean]("SLAVEOF") {
+    def params = node match {
+      case Some((h: String, p: Int)) => h +: p +: ANil
+      case _ => "NO" +: "ONE" +: ANil
+    }
   }
 
 
   object Client {
 
-    case object GetName extends RedisCommand[Option[String]] {
-      def line = multiBulk(Seq("CLIENT", "GETNAME"))
+    case object GetName extends RedisCommand[Option[String]]("CLIENT") {
+      def params = "GETNAME" +: ANil
     }
 
-    case class SetName(name: String) extends RedisCommand[Boolean] {
-      def line = multiBulk(Seq("CLIENT", "SETNAME", name))
+    case class SetName(name: String) extends RedisCommand[Boolean]("CLIENT") {
+      def params = "SETNAME" +: ANil
     }
 
-    case class Kill(ipPort: String) extends RedisCommand[Boolean] {
-      def line = multiBulk(Seq("CLIENT", "KILL", ipPort))
+    case class Kill(ipPort: String) extends RedisCommand[Boolean]("CLIENT") {
+      def params = "KILL" +: ipPort +: ANil
     }
 
-    case object List extends RedisCommand[Option[String]] {
-      def line = multiBulk(Seq("CLIENT", "LIST"))
+    case object List extends RedisCommand[Option[String]]("CLIENT") {
+      def params = "LIST" +: ANil
     }
 
   }
@@ -63,20 +65,20 @@ object NodeCommands {
 
   object Config {
 
-    case class Get[A](globStyleParam: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
-      def line = multiBulk(Seq("CONFIG", "GET", globStyleParam))
+    case class Get[A](globStyleParam: String)(implicit reader: Reader[A]) extends RedisCommand[Option[A]]("CONFIG") {
+      def params = "GET" +: globStyleParam +: ANil
     }
 
-    case class Set(param: String, value: Stringified) extends RedisCommand[Boolean] {
-      def line = multiBulk("CONFIG" +: Seq("SET", param, value.toString))
+    case class Set(param: String, value: Stringified) extends RedisCommand[Boolean]("CONFIG") {
+      def params = "SET" +: param +: value +: ANil
     }
 
-    case object ResetStat extends RedisCommand[Boolean] {
-      def line = multiBulk(Seq("CONFIG", "RESETSTAT"))
+    case object ResetStat extends RedisCommand[Boolean]("CONFIG") {
+      def params = "RESETSTAT" +: ANil
     }
 
-    case object Rewrite extends RedisCommand[Boolean] {
-      def line = multiBulk(Seq("CONFIG", "REWRITE"))
+    case object Rewrite extends RedisCommand[Boolean]("CONFIG") {
+      def params = "REWRITE" +: ANil
     }
 
   }

--- a/src/main/scala/com/redis/protocol/RedisCommand.scala
+++ b/src/main/scala/com/redis/protocol/RedisCommand.scala
@@ -1,36 +1,48 @@
 package com.redis.protocol
 
-import akka.util.{ByteString, ByteStringBuilder}
-import com.redis.serialization.{KeyValuePair, PartialDeserializer}
+import akka.util.CompactByteString
+import com.redis.serialization._
 
 
-abstract class RedisCommand[A]()(implicit _des: PartialDeserializer[A]) {
+abstract class RedisCommand[A](_cmd: String)(implicit _des: PartialDeserializer[A]) {
+  import RedisCommand._
 
   type Ret = A
 
-  // command input : the request protocol of redis (upstream)
-  def line: ByteString
+  val cmd = CompactByteString(_cmd)
+
+  def params: Args
 
   def des = _des
 }
 
+
 object RedisCommand {
 
-  def flattenPairs(in: Iterable[KeyValuePair]) =
-    in.iterator.flatMap(x => Iterator(x.key, x.value.toString)).toList
-  
-  def multiBulk(args: Seq[String]): ByteString = {
-    val b = new ByteStringBuilder
-    b += Multi
-    b ++= ByteString(args.size.toString)
-    b ++= Newline
-    args foreach { arg =>
-      b += Bulk
-      b ++= ByteString(arg.size.toString)
-      b ++= Newline
-      b ++= ByteString(arg)
-      b ++= Newline
-    }
-    b.result
+  class Args (val values: Seq[Stringified]) extends AnyVal {
+    import Stringified._
+
+    def :+(x: Stringified): Args = new Args(values :+ x)
+    def :+[A: Writer](x: A): Args = this :+ x.stringify
+
+    def +:(x: Stringified): Args = new Args(x +: values)
+    def +:[A: Writer](x: A): Args = x.stringify +: this
+
+    def ++(xs: Seq[Stringified]): Args = new Args(values ++ xs)
+    def ++[A: Writer](xs: Seq[A]): Args = this ++ (xs.map(_.stringify))
+
+    def ++:(xs: Seq[Stringified]): Args = new Args(xs ++: values)
+    def ++:[A: Writer](xs: Seq[A]): Args = xs.map(_.stringify) ++: this
+
+    def size = values.size
+
+    def foreach(f: Stringified => Unit) = values foreach f
+    def map[A](f: Stringified => A) = values map f
   }
+
+  object Args {
+    val empty = new Args(Nil)
+  }
+
 }
+

--- a/src/main/scala/com/redis/protocol/SetCommands.scala
+++ b/src/main/scala/com/redis/protocol/SetCommands.scala
@@ -1,14 +1,14 @@
 package com.redis.protocol
 
 import com.redis.serialization._
-import RedisCommand._
 
 
 object SetCommands {
+  import DefaultWriters._
 
-  case class SAdd(key: String, values: Seq[Stringified]) extends RedisCommand[Long] {
+  case class SAdd(key: String, values: Seq[Stringified]) extends RedisCommand[Long]("SADD") {
     require(values.nonEmpty)
-    def line = multiBulk("SADD" +: key +: values.map(_.toString))
+    def params = key +: values.toArgs
   }
 
   object SAdd {
@@ -16,9 +16,9 @@ object SetCommands {
   }
 
 
-  case class SRem(key: String, values: Seq[Stringified]) extends RedisCommand[Long] {
+  case class SRem(key: String, values: Seq[Stringified]) extends RedisCommand[Long]("SREM") {
     require(values.nonEmpty)
-    def line = multiBulk("SREM" +: key +: values.map(_.toString))
+    def params = key +: values.toArgs
   }
 
   object SRem {
@@ -26,56 +26,56 @@ object SetCommands {
   }
 
 
-  case class SPop[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
-    def line = multiBulk("SPOP" +: Seq(key))
+  case class SPop[A: Reader](key: String) extends RedisCommand[Option[A]]("SPOP") {
+    def params = key +: ANil
   }
   
-  case class SMove(srcKey: String, destKey: String, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("SMOVE" +: Seq(srcKey, destKey, value.toString))
+  case class SMove(srcKey: String, destKey: String, value: Stringified) extends RedisCommand[Long]("SMOVE") {
+    def params = srcKey +: destKey +: value +: ANil
   }
 
-  case class SCard(key: String) extends RedisCommand[Long] {
-    def line = multiBulk("SCARD" +: Seq(key))
+  case class SCard(key: String) extends RedisCommand[Long]("SCARD") {
+    def params = key +: ANil
   }
 
-  case class SIsMember(key: String, value: Stringified) extends RedisCommand[Boolean] {
-    def line = multiBulk("SISMEMBER" +: Seq(key, value.toString))
+  case class SIsMember(key: String, value: Stringified) extends RedisCommand[Boolean]("SISMEMBER") {
+    def params = key +: value +: ANil
   }
 
 
-  case class SInter[A](keys: Seq[String])(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SInter[A: Reader](keys: Seq[String]) extends RedisCommand[Set[A]]("SINTER") {
     require(keys.nonEmpty)
-    def line = multiBulk("SINTER" +: keys)
+    def params = keys.toArgs
   }
 
   object SInter {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): SInter[A] = SInter(key +: keys)
+    def apply[A: Reader](key: String, keys: String*): SInter[A] = SInter(key +: keys)
   }
 
   
-  case class SUnion[A](keys: Seq[String])(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SUnion[A: Reader](keys: Seq[String]) extends RedisCommand[Set[A]]("SUNION") {
     require(keys.nonEmpty)
-    def line = multiBulk("SUNION" +: keys)
+    def params = keys.toArgs
   }
 
   object SUnion {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): SUnion[A] = SUnion(key +: keys)
+    def apply[A: Reader](key: String, keys: String*): SUnion[A] = SUnion(key +: keys)
   }
 
 
-  case class SDiff[A](keys: Seq[String])(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
+  case class SDiff[A: Reader](keys: Seq[String]) extends RedisCommand[Set[A]]("SDIFF") {
     require(keys.nonEmpty)
-    def line = multiBulk("SDIFF" +: keys)
+    def params = keys.toArgs
   }
 
   object SDiff {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): SDiff[A] = SDiff(key +: keys)
+    def apply[A: Reader](key: String, keys: String*): SDiff[A] = SDiff(key +: keys)
   }
 
 
-  case class SInterStore(destKey: String, keys: Seq[String]) extends RedisCommand[Long] {
+  case class SInterStore(destKey: String, keys: Seq[String]) extends RedisCommand[Long]("SINTERSTORE") {
     require(keys.nonEmpty)
-    def line = multiBulk("SINTERSTORE" +: destKey +: keys)
+    def params = destKey +: keys.toArgs
   }
 
   object SInterStore {
@@ -84,9 +84,9 @@ object SetCommands {
   }
 
 
-  case class SUnionStore(destKey: String, keys: Seq[String]) extends RedisCommand[Long] {
+  case class SUnionStore(destKey: String, keys: Seq[String]) extends RedisCommand[Long]("SUNIONSTORE") {
     require(keys.nonEmpty)
-    def line = multiBulk("SUNIONSTORE" +: destKey +: keys)
+    def params = destKey +: keys.toArgs
   }
 
   object SUnionStore {
@@ -95,9 +95,9 @@ object SetCommands {
   }
 
 
-  case class SDiffStore(destKey: String, keys: Seq[String]) extends RedisCommand[Long] {
+  case class SDiffStore(destKey: String, keys: Seq[String]) extends RedisCommand[Long]("SDIFFSTORE") {
     require(keys.nonEmpty)
-    def line = multiBulk("SDIFFSTORE" +: destKey +: keys)
+    def params = destKey +: keys.toArgs
   }
 
   object SDiffStore {
@@ -106,15 +106,16 @@ object SetCommands {
   }
 
 
-  case class SMembers[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Set[A]] {
-    def line = multiBulk("SMEMBERS" +: Seq(key))
+  case class SMembers[A: Reader](key: String) extends RedisCommand[Set[A]]("SMEMBERS") {
+    def params = key +: ANil
   }
 
-  case class SRandMember[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
-    def line = multiBulk("SRANDMEMBER" +: Seq(key))
+  case class SRandMember[A: Reader](key: String) extends RedisCommand[Option[A]]("SRANDMEMBER") {
+    def params = key +: ANil
   }
 
-  case class SRandMembers[A](key: String, count: Int)(implicit reader: Read[A]) extends RedisCommand[List[A]] {
-    def line = multiBulk("SRANDMEMBER" +: (Seq(key, count.toString)))
+  case class SRandMembers[A: Reader](key: String, count: Int) extends RedisCommand[List[A]]("SRANDMEMBER") {
+    def params = key +: count +: ANil
   }
+
 }

--- a/src/main/scala/com/redis/protocol/SortedSetCommands.scala
+++ b/src/main/scala/com/redis/protocol/SortedSetCommands.scala
@@ -1,20 +1,18 @@
 package com.redis.protocol
 
 import com.redis.serialization._
-import RedisCommand._
 
 
 object SortedSetCommands {
+  import DefaultWriters._
+
 
   val `+Inf` = Double.PositiveInfinity
   val `-Inf` = Double.NegativeInfinity
 
-
-  case class ZAdd(key: String, scoreMembers: Seq[ScoredValue]) extends RedisCommand[Long] {
+  case class ZAdd(key: String, scoreMembers: Seq[ScoredValue]) extends RedisCommand[Long]("ZADD") {
     require(scoreMembers.nonEmpty)
-    def line = multiBulk(
-      "ZADD" +: key +: scoreMembers.foldRight(List[String]())((x, acc) => x.score.toString +: x.value.toString +: acc)
-    )
+    def params = key +: scoreMembers.foldRight (ANil) { (x, acc) => x.score +: x.value +: acc }
   }
 
   object ZAdd {
@@ -26,9 +24,9 @@ object SortedSetCommands {
   }
 
 
-  case class ZRem(key: String, members: Seq[Stringified]) extends RedisCommand[Long] {
+  case class ZRem(key: String, members: Seq[Stringified]) extends RedisCommand[Long]("ZREM") {
     require(members.nonEmpty)
-    def line = multiBulk("ZREM" +: key +: members.map(_.toString))
+    def params = key +: members.toArgs
   }
 
   object ZRem {
@@ -36,46 +34,46 @@ object SortedSetCommands {
   }
 
   
-  case class ZIncrby(key: String, incr: Double, member: Stringified) extends RedisCommand[Option[Double]] {
-    def line = multiBulk("ZINCRBY" +: Seq(key, incr.toString, member.toString))
+  case class ZIncrby(key: String, incr: Double, member: Stringified) extends RedisCommand[Option[Double]]("ZINCRBY") {
+    def params = key +: incr +: member +: ANil
   }
   
-  case class ZCard(key: String) extends RedisCommand[Long] {
-    def line = multiBulk("ZCARD" +: Seq(key))
+  case class ZCard(key: String) extends RedisCommand[Long]("ZCARD") {
+    def params = key +: ANil
   }
   
-  case class ZScore(key: String, element: Stringified) extends RedisCommand[Option[Double]] {
-    def line = multiBulk("ZSCORE" +: Seq(key, element.toString))
+  case class ZScore(key: String, element: Stringified) extends RedisCommand[Option[Double]]("ZSCORE") {
+    def params = key +: element +: ANil
   }
 
 
   case class ZRange[A](key: String, start: Int = 0, end: Int = -1)
-                      (implicit reader: Read[A]) extends RedisCommand[List[A]] {
-    def line = multiBulk("ZRANGE" +: key +: start.toString +: end.toString +: Nil)
+                      (implicit reader: Reader[A]) extends RedisCommand[List[A]]("ZRANGE") {
+    def params = key +: start +: end +: ANil
 
-    def reverse = ZRevRange(key, start, end)
+    def reverse = ZRevRange(key, start, end)(reader)
 
-    def withScores = ZRangeWithScores[A](key, start, end)
+    def withScores = ZRangeWithScores[A](key, start, end)(reader)
   }
 
   case class ZRangeWithScores[A](key: String, start: Int = 0, end: Int = -1)
-                                (implicit reader: Read[A]) extends RedisCommand[List[(A, Double)]] {
-    def line = multiBulk("ZRANGE" +: key +: start.toString +: end.toString +: "WITHSCORES" +: Nil)
+                                (implicit reader: Reader[A]) extends RedisCommand[List[(A, Double)]]("ZRANGE") {
+    def params = key +: start +: end +: "WITHSCORES" +: ANil
 
-    def reverse = ZRangeWithScores(key, start, end)
+    def reverse = ZRangeWithScores(key, start, end)(reader)
   }
 
 
   case class ZRevRange[A](key: String, start: Int = 0, end: Int = -1)
-                      (implicit reader: Read[A]) extends RedisCommand[List[A]] {
-    def line = multiBulk("ZREVRANGE" +: key +: start.toString +: end.toString +: Nil)
+                      (implicit reader: Reader[A]) extends RedisCommand[List[A]]("ZREVRANGE") {
+    def params = key +: start +: end +: ANil
 
-    def withScores = ZRevRangeWithScores[A](key, start, end)
+    def withScores = ZRevRangeWithScores[A](key, start, end)(reader)
   }
 
   case class ZRevRangeWithScores[A](key: String, start: Int = 0, end: Int = -1)
-                         (implicit reader: Read[A]) extends RedisCommand[List[(A, Double)]] {
-    def line = multiBulk("ZREVRANGE" +: key +: start.toString +: end.toString +: "WITHSCORES" +: Nil)
+                                   (implicit reader: Reader[A]) extends RedisCommand[List[(A, Double)]]("ZREVRANGE") {
+    def params = key +: start +: end +: "WITHSCORES" +: ANil
   }
 
 
@@ -83,80 +81,78 @@ object SortedSetCommands {
                               min: Double = `-Inf`, minInclusive: Boolean = true,
                               max: Double = `+Inf`, maxInclusive: Boolean = true,
                               limit: Option[(Int, Int)] = None)
-                             (implicit reader: Read[A]) extends RedisCommand[List[A]] {
+                             (implicit reader: Reader[A]) extends RedisCommand[List[A]]("ZRANGEBYSCORE") {
 
-    def line = multiBulk("ZRANGEBYSCORE" +: key +: scoreParams(min, minInclusive, max, maxInclusive, limit, false))
+    def params = key +: scoreParams(min, minInclusive, max, maxInclusive, limit, false)
 
-    def reverse = ZRevRangeByScore(key, min, minInclusive, max, maxInclusive, limit)
+    def reverse = ZRevRangeByScore(key, min, minInclusive, max, maxInclusive, limit)(reader)
 
-    def withScores = ZRangeByScoreWithScores[A](key, min, minInclusive, max, maxInclusive, limit)
+    def withScores = ZRangeByScoreWithScores[A](key, min, minInclusive, max, maxInclusive, limit)(reader)
   }
 
   case class ZRangeByScoreWithScores[A](key: String,
                                         min: Double = `-Inf`, minInclusive: Boolean = true,
                                         max: Double = `+Inf`, maxInclusive: Boolean = true,
                                         limit: Option[(Int, Int)] = None)
-                                       (implicit reader: Read[A]) extends RedisCommand[List[(A, Double)]] {
+                                       (implicit reader: Reader[A]) extends RedisCommand[List[(A, Double)]]("ZRANGEBYSCORE") {
 
-    def line = multiBulk("ZRANGEBYSCORE" +: key +: scoreParams(min, minInclusive, max, maxInclusive, limit, true))
+    def params = key +: scoreParams(min, minInclusive, max, maxInclusive, limit, true)
 
-    def reverse = ZRevRangeByScoreWithScores(key, min, minInclusive, max, maxInclusive, limit)
+    def reverse = ZRevRangeByScoreWithScores(key, min, minInclusive, max, maxInclusive, limit)(reader)
   }
 
   case class ZRevRangeByScore[A](key: String,
                                  max: Double = `+Inf`, maxInclusive: Boolean = true,
                                  min: Double = `-Inf`, minInclusive: Boolean = true,
                                  limit: Option[(Int, Int)] = None)
-                                (implicit reader: Read[A]) extends RedisCommand[List[A]] {
+                                (implicit reader: Reader[A]) extends RedisCommand[List[A]]("ZREVRANGEBYSCORE") {
 
-    def line = multiBulk("ZREVRANGEBYSCORE" +: key +: scoreParams(max, maxInclusive, min, minInclusive, limit, false))
+    def params = key +: scoreParams(max, maxInclusive, min, minInclusive, limit, false)
 
-    def withScores = ZRevRangeByScoreWithScores(key, min, minInclusive, max, maxInclusive, limit)
+    def withScores = ZRevRangeByScoreWithScores(key, min, minInclusive, max, maxInclusive, limit)(reader)
   }
 
   case class ZRevRangeByScoreWithScores[A](key: String,
                                            max: Double = `+Inf`, maxInclusive: Boolean = true,
                                            min: Double = `-Inf`, minInclusive: Boolean = true,
                                            limit: Option[(Int, Int)] = None)
-                                          (implicit reader: Read[A]) extends RedisCommand[List[(A, Double)]] {
+                                          (implicit reader: Reader[A]) extends RedisCommand[List[(A, Double)]]("ZREVRANGEBYSCORE") {
 
-    def line = multiBulk("ZREVRANGEBYSCORE" +: key +: scoreParams(max, maxInclusive, min, minInclusive, limit, true))
+    def params = key +: scoreParams(max, maxInclusive, min, minInclusive, limit, true)
   }
 
   private def scoreParams(from: Double, fromInclusive: Boolean, to: Double, toInclusive: Boolean,
-                          limit: Option[(Int, Int)], withScores: Boolean): Seq[String] = {
-
-    import Write.Internal.formatDouble
+                          limit: Option[(Int, Int)], withScores: Boolean): Args = {
 
     formatDouble(from, fromInclusive) +: formatDouble(to, toInclusive) +: (
-      (if (withScores) Seq("WITHSCORES") else Seq.empty[String]) ++
+      (if (withScores) Seq("WITHSCORES") else Nil) ++:
       (limit match {
-        case Some((from, to)) => "LIMIT" +: from.toString +: to.toString +: Nil
-        case _ => Seq.empty[String]
+        case Some((from, to)) => "LIMIT" +: from +: to +: ANil
+        case _ => ANil
       })
     )
   }
 
 
   case class ZRank(key: String, member: Stringified)
-      extends RedisCommand[Option[Long]]()(PartialDeserializer.liftOptionPD[Long]) {
-    def line = multiBulk("ZRANK" +: key +: member.toString +: Nil)
+      extends RedisCommand[Option[Long]]("ZRANK")(PartialDeserializer.liftOptionPD[Long]) {
+    def params = key +: member +: ANil
 
     def reverse = ZRevRank(key, member)
   }
 
   case class ZRevRank(key: String, member: Stringified)
-      extends RedisCommand[Option[Long]]()(PartialDeserializer.liftOptionPD[Long]) {
-    def line = multiBulk("ZREVRANK" +: key +: member.toString +: Nil)
+      extends RedisCommand[Option[Long]]("ZREVRANK")(PartialDeserializer.liftOptionPD[Long]) {
+    def params = key +: member +: ANil
   }
 
 
-  case class ZRemRangeByRank(key: String, start: Int = 0, end: Int = -1) extends RedisCommand[Long] {
-    def line = multiBulk("ZREMRANGEBYRANK" +: key +: start.toString +: end.toString +: Nil)
+  case class ZRemRangeByRank(key: String, start: Int = 0, end: Int = -1) extends RedisCommand[Long]("ZREMRANGEBYRANK") {
+    def params = key +: start +: end +: ANil
   }
 
-  case class ZRemRangeByScore(key: String, start: Double = `-Inf`, end: Double = `+Inf`) extends RedisCommand[Long] {
-    def line = multiBulk("ZREMRANGEBYSCORE" +: key +: start.toString +: end.toString +: Nil)
+  case class ZRemRangeByScore(key: String, start: Double = `-Inf`, end: Double = `+Inf`) extends RedisCommand[Long]("ZREMRANGEBYSCORE") {
+    def params = key +: start +: end +: ANil
   }
 
 
@@ -166,43 +162,50 @@ object SortedSetCommands {
   case object MAX extends Aggregate
 
   case class ZInterStore(dstKey: String, keys: Iterable[String],
-                         aggregate: Aggregate = SUM) extends RedisCommand[Long] {
+                         aggregate: Aggregate = SUM) extends RedisCommand[Long]("ZINTERSTORE") {
 
-    def line = multiBulk("ZINTERSTORE" +:
-      (Iterator(dstKey, keys.size.toString) ++ keys.iterator ++ Iterator("AGGREGATE", aggregate.toString)).toSeq)
+    def params =
+      (Iterator(dstKey, keys.size.toString) ++ keys.iterator ++ Iterator("AGGREGATE", aggregate.toString)).toSeq.toArgs
   }
 
   case class ZUnionStore(dstKey: String, keys: Iterable[String],
-                         aggregate: Aggregate = SUM) extends RedisCommand[Long] {
+                         aggregate: Aggregate = SUM) extends RedisCommand[Long]("ZUNIONSTORE") {
 
-    def line = multiBulk("ZUNIONSTORE" +:
-      (Iterator(dstKey, keys.size.toString) ++ keys.iterator ++ Iterator("AGGREGATE", aggregate.toString)).toSeq)
+    def params =
+      (Iterator(dstKey, keys.size.toString) ++ keys.iterator ++ Iterator("AGGREGATE", aggregate.toString)).toSeq.toArgs
   }
 
   case class ZInterStoreWeighted(dstKey: String, kws: Iterable[Product2[String, Double]],
-                                 aggregate: Aggregate = SUM) extends RedisCommand[Long] {
+                                 aggregate: Aggregate = SUM) extends RedisCommand[Long]("ZINTERSTORE") {
 
-    def line = multiBulk("ZINTERSTORE" +:
+    def params =
       (Iterator(dstKey, kws.size.toString) ++ kws.iterator.map(_._1) ++ Iterator.single("WEIGHTS") ++
-        kws.iterator.map(_._2.toString) ++ Iterator("AGGREGATE", aggregate.toString)).toSeq
-    )
+        kws.iterator.map(_._2.toString) ++ Iterator("AGGREGATE", aggregate.toString)).toSeq.toArgs
   }
 
   case class ZUnionStoreWeighted(dstKey: String, kws: Iterable[Product2[String, Double]],
-                                 aggregate: Aggregate = SUM) extends RedisCommand[Long] {
+                                 aggregate: Aggregate = SUM) extends RedisCommand[Long]("ZUNIONSTORE") {
 
-    def line = multiBulk("ZUNIONSTORE" +:
+    def params =
       (Iterator(dstKey, kws.size.toString) ++ kws.iterator.map(_._1) ++ Iterator.single("WEIGHTS") ++
-        kws.iterator.map(_._2.toString) ++ Iterator("AGGREGATE", aggregate.toString)).toSeq
-    )
+        kws.iterator.map(_._2.toString) ++ Iterator("AGGREGATE", aggregate.toString)).toSeq.toArgs
   }
 
   case class ZCount(key: String,
                     min: Double = `-Inf`, minInclusive: Boolean = true,
-                    max: Double = `+Inf`, maxInclusive: Boolean = true) extends RedisCommand[Long] {
-    import Write.Internal.formatDouble
+                    max: Double = `+Inf`, maxInclusive: Boolean = true) extends RedisCommand[Long]("ZCOUNT") {
 
-    def line =
-      multiBulk("ZCOUNT" +: key +: formatDouble(min, minInclusive) +: formatDouble(max, maxInclusive) +: Nil)
+    def params = key +: formatDouble(min, minInclusive) +: formatDouble(max, maxInclusive) +: ANil
   }
+
+
+  private def formatDouble(d: Double, inclusive: Boolean = true) = Stringified(
+    (if (inclusive) ("") else ("(")) + {
+      if (d.isInfinity) {
+        if (d > 0.0) "+inf" else "-inf"
+      } else {
+        d.toString
+      }
+    }
+  )
 }

--- a/src/main/scala/com/redis/protocol/StringCommands.scala
+++ b/src/main/scala/com/redis/protocol/StringCommands.scala
@@ -2,29 +2,30 @@ package com.redis.protocol
 
 import scala.language.existentials
 import com.redis.serialization._
-import RedisCommand._
 
 
 object StringCommands {
-  case class Get[A](key: String)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
-    def line = multiBulk("GET" +: key +: Nil)
+  import DefaultWriters._
+
+  case class Get[A: Reader](key: String) extends RedisCommand[Option[A]]("GET") {
+    def params = key +: ANil
   }
 
-  sealed trait SetOption { def toSeq: Seq[String] }
+  sealed trait SetOption { def toArgs: Args }
 
-  sealed abstract class SetExpiryOption(label: String, n: Long) extends SetOption { def toSeq = Seq(label, n.toString) }
+  sealed abstract class SetExpiryOption(label: String, n: Long) extends SetOption { def toArgs = label +: n +: ANil }
   case class EX(expiryInSeconds: Long) extends SetExpiryOption("EX", expiryInSeconds)
   case class PX(expiryInMillis: Long) extends SetExpiryOption("PX", expiryInMillis)
 
-  sealed abstract class SetConditionOption(label: String) extends SetOption { def toSeq = Seq(label) }
+  sealed abstract class SetConditionOption(label: String) extends SetOption { def toArgs = label +: ANil }
   case object NX extends SetConditionOption("NX")
   case object XX extends SetConditionOption("XX")
 
   case class Set(key: String, value: Stringified,
                  exORpx: Option[SetExpiryOption] = None,
-                 nxORxx: Option[SetConditionOption] = None) extends RedisCommand[Boolean] {
+                 nxORxx: Option[SetConditionOption] = None) extends RedisCommand[Boolean]("SET") {
 
-    def line = multiBulk("SET" +: key +: value.toString +: (exORpx.toSeq ++ nxORxx.toSeq).flatMap(_.toSeq))
+    def params = key +: value +: exORpx.fold[Seq[Stringified]](Nil)(_.toArgs.values) ++: nxORxx.fold(ANil)(_.toArgs)
   }
 
   object Set {
@@ -40,91 +41,97 @@ object StringCommands {
   }
 
 
-  case class GetSet[A](key: String, value: Stringified)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
-    def line = multiBulk("GETSET" +: key +: value.toString +: Nil)
+  case class GetSet[A: Reader](key: String, value: Stringified) extends RedisCommand[Option[A]]("GETSET") {
+    def params = key +: value +: ANil
   }
   
-  case class SetNx(key: String, value: Stringified) extends RedisCommand[Boolean] {
-    def line = multiBulk("SETNX" +: key +: value.toString +: Nil)
+  case class SetNx(key: String, value: Stringified) extends RedisCommand[Boolean]("SETNX") {
+    def params = key +: value +: ANil
   }
   
-  case class SetEx(key: String, expiry: Long, value: Stringified) extends RedisCommand[Boolean] {
-    def line = multiBulk("SETEX" +: key +: expiry.toString +: value.toString +: Nil)
+  case class SetEx(key: String, expiry: Long, value: Stringified) extends RedisCommand[Boolean]("SETEX") {
+    def params = key +: expiry +: value +: ANil
   }
   
-  case class PSetEx(key: String, expiryInMillis: Long, value: Stringified) extends RedisCommand[Boolean] {
-    def line = multiBulk("PSETEX" +: key +: expiryInMillis.toString +: value.toString +: Nil)
+  case class PSetEx(key: String, expiryInMillis: Long, value: Stringified) extends RedisCommand[Boolean]("PSETEX") {
+    def params = key +: expiryInMillis +: value +: ANil
   }
 
   
-  case class Incr(key: String) extends RedisCommand[Long] {
-    def line = multiBulk("INCR" +: key +: Nil)
+  case class Incr(key: String) extends RedisCommand[Long]("INCR") {
+    def params = key +: ANil
   }
 
-  case class IncrBy(key: String, amount: Int) extends RedisCommand[Long] {
-    def line = multiBulk("INCRBY" +: key +: amount.toString +: Nil)
-  }
-
-
-  case class Decr(key: String) extends RedisCommand[Long] {
-    def line = multiBulk("DECR" +: key +: Nil)
-  }
-
-  case class DecrBy(key: String, amount: Int) extends RedisCommand[Long] {
-    def line = multiBulk("DECRBY" +: key +: amount.toString +: Nil)
+  case class IncrBy(key: String, amount: Int) extends RedisCommand[Long]("INCRBY") {
+    def params = key +: amount +: ANil
   }
 
 
-  case class MGet[A](keys: Seq[String])(implicit reader: Read[A])
-      extends RedisCommand[Map[String, A]]()(PartialDeserializer.keyedMapPD(keys)) {
+  case class Decr(key: String) extends RedisCommand[Long]("DECR") {
+    def params = key +: ANil
+  }
+
+  case class DecrBy(key: String, amount: Int) extends RedisCommand[Long]("DECRBY") {
+    def params = key +: amount +: ANil
+  }
+
+
+  case class MGet[A: Reader](keys: Seq[String])
+      extends RedisCommand[Map[String, A]]("MGET")(PartialDeserializer.keyedMapPD(keys)) {
     require(keys.nonEmpty)
-    def line = multiBulk("MGET" +: keys)
+    def params = keys.toArgs
   }
 
   object MGet {
-    def apply[A](key: String, keys: String*)(implicit reader: Read[A]): MGet[A] = MGet(key +: keys)
+    def apply[A: Reader](key: String, keys: String*): MGet[A] = MGet(key +: keys)
   }
 
 
-  case class MSet(kvs: KeyValuePair*) extends RedisCommand[Boolean] {
-    def line = multiBulk("MSET" +: kvs.foldRight(Seq[String]()){ case (KeyValuePair(k,v),l) => k +: v.toString +: l })
+  case class MSet(kvs: KeyValuePair*) extends RedisCommand[Boolean]("MSET") {
+    def params = kvs.foldRight(ANil) { case (KeyValuePair(k, v), l) => k +: v +: l }
   }
 
-  case class MSetNx(kvs: KeyValuePair*) extends RedisCommand[Boolean] {
-    def line = multiBulk("MSETNX" +: kvs.foldRight(Seq[String]()){ case (KeyValuePair(k,v),l) => k +: v.toString +: l })
+  case class MSetNx(kvs: KeyValuePair*) extends RedisCommand[Boolean]("MSETNX") {
+    def params = kvs.foldRight(ANil) { case (KeyValuePair(k, v), l) => k +: v +: l }
   }
   
-  case class SetRange(key: String, offset: Int, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("SETRANGE" +: Seq(key, offset.toString, value.toString))
+  case class SetRange(key: String, offset: Int, value: Stringified) extends RedisCommand[Long]("SETRANGE") {
+    def params = key +: offset +: value +: ANil
   }
 
-  case class GetRange[A](key: String, start: Int, end: Int)(implicit reader: Read[A]) extends RedisCommand[Option[A]] {
-    def line = multiBulk("GETRANGE" +: key +: Seq(start, end).map(_.toString))
+  case class GetRange[A: Reader](key: String, start: Int, end: Int) extends RedisCommand[Option[A]]("GETRANGE") {
+    def params = key +: start +: end +: ANil
   }
   
-  case class Strlen(key: String) extends RedisCommand[Long] {
-    def line = multiBulk("STRLEN" +: Seq(key))
+  case class Strlen(key: String) extends RedisCommand[Long]("STRLEN") {
+    def params = key +: ANil
   }
   
-  case class Append(key: String, value: Stringified) extends RedisCommand[Long] {
-    def line = multiBulk("APPEND" +: Seq(key, value.toString))
+  case class Append(key: String, value: Stringified) extends RedisCommand[Long]("APPEND") {
+    def params = key +: value +: ANil
   }
   
-  case class GetBit(key: String, offset: Int) extends RedisCommand[Boolean] {
-    def line = multiBulk("GETBIT" +: Seq(key, offset.toString))
+  case class GetBit(key: String, offset: Int) extends RedisCommand[Boolean]("GETBIT") {
+    def params = key +: offset +: ANil
   }
   
-  case class SetBit(key: String, offset: Int, value: Boolean) extends RedisCommand[Long] {
-    def line = multiBulk("SETBIT" +: Seq(key, offset.toString, Write.Internal.formatBoolean(value)))
+  case class SetBit(key: String, offset: Int, value: Boolean) extends RedisCommand[Long]("SETBIT") {
+    def params = key +: offset +: (if (value) "1" else "0") +: ANil
   }
-  
-  case class BitOp(op: String, destKey: String, srcKeys: String*) extends RedisCommand[Long] {
-    def line = multiBulk("BITOP" +: op +: destKey +: srcKeys)
+
+
+  case class BitOp(op: String, destKey: String, srcKeys: Seq[String]) extends RedisCommand[Long]("BITOP") {
+    require(srcKeys.nonEmpty)
+    def params = op +: destKey +: srcKeys.toArgs
   }
-  
-  case class BitCount(key: String, range: Option[(Int, Int)]) extends RedisCommand[Long] {
-    def line = multiBulk("BITCOUNT" +: key +:
-      range.fold (Seq.empty[String]) { case (from, to) => Seq(from, to).map(_.toString) })
+
+  object BitOp {
+    def apply(op: String, destKey: String, srcKey: String, srcKeys: String*): BitOp = BitOp(op, destKey, srcKey +: srcKeys)
+  }
+
+
+  case class BitCount(key: String, range: Option[(Int, Int)]) extends RedisCommand[Long]("BITCOUNT") {
+    def params = key +: range.fold(ANil) { case (from, to) => from +: to +: ANil }
   }
 }
 

--- a/src/main/scala/com/redis/protocol/package.scala
+++ b/src/main/scala/com/redis/protocol/package.scala
@@ -4,6 +4,7 @@ import akka.io.Tcp
 import akka.actor.ActorRef
 import akka.util.ByteString
 import scala.language.existentials
+import com.redis.serialization.{Writer, Stringified}
 
 
 package object protocol {
@@ -28,6 +29,18 @@ package object protocol {
 
   case class RedisError(message: String) extends Throwable(message)
 
+
+  type Args = RedisCommand.Args
+
+  val ANil = RedisCommand.Args.empty
+
+  implicit class StringifiedArgsOps(values: Seq[Stringified]) {
+    def toArgs = new Args(values)
+  }
+
+  implicit class ArgsOps[A: Writer](values: Seq[A]) {
+    def toArgs = new Args(values)
+  }
 
   /**
    * Response codes from the Redis server

--- a/src/main/scala/com/redis/serialization/Format.scala
+++ b/src/main/scala/com/redis/serialization/Format.scala
@@ -1,47 +1,95 @@
 package com.redis.serialization
 
+import akka.util.{ByteString, CompactByteString}
 import scala.annotation.implicitNotFound
 import scala.language.implicitConversions
 
 
 @implicitNotFound(msg = "Cannot find implicit Read or Format type class for ${A}")
-trait Read[A] {
-  def read(in: String): A
+private[redis] trait Reader[A] {
+  def fromByteString(in: ByteString): A
 }
 
-object Read {
-  def apply[A](f: String => A) = new Read[A] { def read(in: String) = f(in) }
+private[redis] trait ReaderLowPriorityImplicits {
+  implicit object bypassingReader extends Reader[ByteString] {
+    def fromByteString(in: ByteString) = in
+  }
 
-  implicit def default: Read[String] = DefaultFormats.stringFormat
+  implicit object byteArrayReader extends Reader[Array[Byte]] {
+    def fromByteString(in: ByteString) = in.toArray[Byte]
+  }
+}
+
+object Reader extends ReaderLowPriorityImplicits {
+  implicit def default: Reader[String] = DefaultFormats.stringFormat
 }
 
 
 @implicitNotFound(msg = "Cannot find implicit Write or Format type class for ${A}")
-trait Write[A] {
-  def write(in: A): String
+private[redis] trait Writer[A] {
+  private[redis] def toByteString(in: A): ByteString
 }
 
-object Write {
-  def apply[A](f: A => String) = new Write[A] { def write(in: A) = f(in) }
+private[redis] trait WriterLowPriorityImplicits {
+  implicit object bypassingWriter extends Writer[ByteString] {
+    def toByteString(in: ByteString) = in
+  }
 
-  implicit def default: Write[String] = DefaultFormats.stringFormat
-
-  private[redis] object Internal {
-    def formatBoolean(b: Boolean) = if (b) "1" else "0"
-
-    def formatDouble(d: Double, inclusive: Boolean = true) =
-      (if (inclusive) ("") else ("(")) + {
-        if (d.isInfinity) {
-          if (d > 0.0) "+inf" else "-inf"
-        } else {
-          d.toString
-        }
-      }
+  implicit object byteArrayWriter extends Writer[Array[Byte]] {
+    def toByteString(in: Array[Byte]) =  CompactByteString(in)
   }
 }
 
+object Writer extends WriterLowPriorityImplicits {
+  implicit def default: Writer[String] = DefaultFormats.stringFormat
+}
 
-trait Format[A] extends Read[A] with Write[A]
+
+
+trait StringReader[A] extends Reader[A] {
+  def read(in: String): A
+
+  def fromByteString(in: ByteString): A = read(in.utf8String)
+}
+
+object StringReader {
+  def apply[A](f: String => A) = new StringReader[A] { def read(in: String) = f(in) }
+}
+
+trait DefaultReaders {
+  import java.{lang => J}
+  implicit val intReader    = StringReader[Int]   (J.Integer.parseInt)
+  implicit val shortReader  = StringReader[Short] (J.Short.parseShort)
+  implicit val longReader   = StringReader[Long]  (J.Long.parseLong)
+  implicit val floatReader  = StringReader[Float] (J.Float.parseFloat)
+  implicit val doubleReader = StringReader[Double](J.Double.parseDouble)
+  implicit val anyReader    = StringReader[Any]   (identity)
+}
+object DefaultReaders extends DefaultReaders
+
+
+trait StringWriter[A] extends Writer[A] {
+  def write(in: A): String
+
+  def toByteString(in: A): ByteString = ByteString(write(in))
+}
+
+object StringWriter {
+  def apply[A](f: A => String) = new StringWriter[A] { def write(in: A) = f(in) }
+}
+
+trait DefaultWriters {
+  implicit val intWriter    = StringWriter[Int]   (_.toString)
+  implicit val shortWriter  = StringWriter[Short] (_.toString)
+  implicit val longWriter   = StringWriter[Long]  (_.toString)
+  implicit val floatWriter  = StringWriter[Float] (_.toString)
+  implicit val doubleWriter = StringWriter[Double](_.toString)
+  implicit val anyWriter    = StringWriter[Any]   (_.toString)
+}
+object DefaultWriters extends DefaultWriters
+
+
+trait Format[A] extends StringReader[A] with StringWriter[A]
 
 object Format {
 
@@ -54,16 +102,8 @@ object Format {
   implicit def default = DefaultFormats.stringFormat
 }
 
-private[serialization] trait LowPriorityFormats {
-  import java.{lang => J}
-  implicit val byteArrayFormat = Format[Array[Byte]](_.getBytes("UTF-8"), new String(_))
-  implicit val intFormat = Format[Int](J.Integer.parseInt, _.toString)
-  implicit val shortFormat = Format[Short](J.Short.parseShort, _.toString)
-  implicit val longFormat = Format[Long](J.Long.parseLong, _.toString)
-  implicit val floatFormat = Format[Float](J.Float.parseFloat, _.toString)
-  implicit val doubleFormat = Format[Double](J.Double.parseDouble, _.toString)
-  implicit val anyFormat = Format[Any](identity, _.toString)
-}
+
+private[serialization] trait LowPriorityFormats extends DefaultReaders with DefaultWriters
 
 trait DefaultFormats extends LowPriorityFormats {
   implicit val stringFormat = Format[String](identity, identity)

--- a/src/main/scala/com/redis/serialization/Integration.scala
+++ b/src/main/scala/com/redis/serialization/Integration.scala
@@ -6,26 +6,26 @@ import scala.language.implicitConversions
 trait SprayJsonSupport {
   import spray.json._
 
-  implicit def sprayJsonReader[A](implicit reader: RootJsonReader[A]): Read[A] =
-    Read(s => reader.read(s.asJson))
+  implicit def sprayJsonStringReader[A](implicit reader: RootJsonReader[A]): Reader[A] =
+    StringReader(s => reader.read(s.asJson))
 
-  implicit def sprayJsonWriter[A](implicit writer: RootJsonWriter[A]): Write[A] =
-    Write(writer.write(_).toString)
+  implicit def sprayJsonStringWriter[A](implicit writer: RootJsonWriter[A]): Writer[A] =
+    StringWriter(writer.write(_).toString)
 }
 
 object SprayJsonSupport extends SprayJsonSupport
 
 
 trait Json4sSupport {
-  import org.json4s._
+  import org.json4s.{Serialization, Formats}
 
   def Serialization: Serialization
 
-  implicit def json4sReader[A](implicit format: Formats, manifest: Manifest[A]): Read[A] =
-    Read(Serialization.read(_))
+  implicit def json4sStringReader[A](implicit format: Formats, manifest: Manifest[A]): Reader[A] =
+    StringReader(Serialization.read(_))
 
-  implicit def json4sWriter[A <: AnyRef](implicit format: Formats): Write[A] =
-    Write(Serialization.write(_))
+  implicit def json4sStringWriter[A <: AnyRef](implicit format: Formats): Writer[A] =
+    StringWriter(Serialization.write(_))
 }
 
 trait Json4sNativeSupport extends Json4sSupport {
@@ -44,11 +44,11 @@ object Json4sJacksonSupport extends Json4sJacksonSupport
 trait LiftJsonSupport {
   import net.liftweb.json._
 
-  implicit def liftJsonReader[A](implicit format: Formats, manifest: Manifest[A]): Read[A] =
-    Read(parse(_).extract[A])
+  implicit def liftJsonStringReader[A](implicit format: Formats, manifest: Manifest[A]): Reader[A] =
+    StringReader(parse(_).extract[A])
 
-  implicit def liftJsonWriter[A <: AnyRef](implicit format: Formats): Write[A] =
-    Write(Serialization.write(_))
+  implicit def liftJsonStringWriter[A <: AnyRef](implicit format: Formats): Writer[A] =
+    StringWriter(Serialization.write(_))
 }
 
 object LiftJsonSupport extends LiftJsonSupport

--- a/src/main/scala/com/redis/serialization/RawReplyParser.scala
+++ b/src/main/scala/com/redis/serialization/RawReplyParser.scala
@@ -1,8 +1,8 @@
 package com.redis.serialization
 
 import scala.annotation.tailrec
-import scala.collection.mutable.ArrayBuilder
-import akka.util.CompactByteString
+
+import akka.util.{ByteString, CompactByteString, ByteStringBuilder}
 import scala.collection.GenTraversable
 import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds
@@ -33,8 +33,8 @@ private[serialization] object RawReplyParser {
   }
 
   // Parse a string of undetermined length
-  def parseSingle(input: RawReply): String = {
-    val builder = ArrayBuilder.make[Byte]
+  def parseSingle(input: RawReply): ByteString = {
+    val builder = new ByteStringBuilder
 
     @tailrec def loop(): Unit =
       input.nextByte() match {
@@ -46,33 +46,23 @@ private[serialization] object RawReplyParser {
 
     loop()
     input.jump(1)
-    new String(builder.result)
+    builder.result
   }
 
   // Parse a string with known length
-  def parseBulk(input: RawReply): Option[String] = {
+  def parseBulk(input: RawReply): Option[ByteString] = {
     val length = parseInt(input)
 
     if (length == NullBulkReplyCount) None
     else {
-      val res = Some(input.take(length).utf8String)
+      val res = Some(input.take(length))
       input.jump(2)
       res
     }
   }
 
-  // Parse a string with known length
-  def parseString(input: RawReply): String = {
-    val length = parseInt(input)
-    require(length != -1, "Non-empty bulk reply expected, but got nil")
-
-    val res = input.take(length).utf8String
-    input.jump(2)
-    res
-  }
-
   def parseError(input: RawReply): RedisError =
-    new RedisError(parseSingle(input))
+    new RedisError(parseSingle(input).utf8String)
 
   def parseMultiBulk[A, B[_] <: GenTraversable[_]](input: RawReply)(implicit cbf: CanBuildFrom[_, A, B[A]], pd: PartialDeserializer[A]): B[A] = {
     val builder = cbf.apply()
@@ -129,17 +119,16 @@ private[serialization] object RawReplyParser {
   }
 
   object PrefixDeserializer {
-    val _intPD           = new PrefixDeserializer[Int]            (Integer, parseInt _)
-    val _longPD          = new PrefixDeserializer[Long]           (Integer, parseLong _)
-    val _stringPD        = new PrefixDeserializer[String]         (Bulk,    parseString _)
-    val _statusStringPD  = new PrefixDeserializer[String]         (Status,  parseSingle _)
-    val _bulkPD          = new PrefixDeserializer[Option[String]] (Bulk,    parseBulk _)
-    val _errorPD         = new PrefixDeserializer[RedisError]     (Err,     parseError _)
+    val _intPD           = new PrefixDeserializer[Int]                 (Integer, parseInt _)
+    val _longPD          = new PrefixDeserializer[Long]                (Integer, parseLong _)
+    val _statusStringPD  = new PrefixDeserializer[ByteString]          (Status,  parseSingle _)
+    val _rawBulkPD       = new PrefixDeserializer[Option[ByteString]]  (Bulk,    parseBulk _)
+    val _errorPD         = new PrefixDeserializer[RedisError]          (Err,     parseError _)
 
     val _booleanPD =
       new PrefixDeserializer[Boolean](Status, (x: RawReply) => {parseSingle(x); true }) orElse
         (_longPD andThen (_ > 0)) orElse
-        (_bulkPD andThen (_.isDefined))
+        (_rawBulkPD andThen (_.isDefined))
 
     def _multiBulkPD[A, B[_] <: GenTraversable[_]](implicit cbf: CanBuildFrom[_, A, B[A]], pd: PartialDeserializer[A]) =
       new PrefixDeserializer[B[A]](Multi, parseMultiBulk(_)(cbf, pd))

--- a/src/main/scala/com/redis/serialization/Stringified.scala
+++ b/src/main/scala/com/redis/serialization/Stringified.scala
@@ -1,34 +1,45 @@
 package com.redis.serialization
 
+import akka.util.ByteString
 import scala.language.implicitConversions
+import scala.collection.generic.CanBuildFrom
+import scala.collection.{SeqLike, GenTraversableOnce, GenTraversable}
 
 
-class Stringified(override val toString: String) extends AnyVal
+class Stringified(val value: ByteString) extends AnyVal {
+  override def toString = value.utf8String
+}
+
 
 object Stringified {
-  implicit def apply[A](v: A)(implicit writer: Write[A]) = new Stringified(writer.write(v))
+  implicit def apply[A](v: A)(implicit writer: Writer[A]) = new Stringified(writer.toByteString(v))
 
-  implicit def applySeq[A](vs: Seq[A])(implicit writer: Write[A]): Seq[Stringified] = vs.map(apply[A])
+  implicit def applySeq[A: Writer](vs: Seq[A]) = vs.map(apply[A])
+
+  implicit class StringifyOps[A: Writer](x: A) {
+    def stringify = Stringified(x)
+  }
 }
 
 
 class KeyValuePair(val pair: Product2[String, Stringified]) extends AnyVal {
-  @inline def key   = pair._1
-  @inline def value = pair._2
+  def key: String       = pair._1
+  def value: Stringified = pair._2
 }
 
 object KeyValuePair {
+  import Stringified._
 
   implicit def apply(pair: Product2[String, Stringified]): KeyValuePair =
     new KeyValuePair(pair)
 
-  implicit def apply[A](pair: Product2[String, A])(implicit writer: Write[A]): KeyValuePair =
-    new KeyValuePair((pair._1, Stringified(pair._2)))
+  implicit def apply[A: Writer](pair: Product2[String, A]): KeyValuePair =
+    new KeyValuePair((pair._1, pair._2.stringify))
 
-  implicit def applySeq[A](pairs: Seq[Product2[String, A]])(implicit writer: Write[A]): Seq[KeyValuePair] =
+  implicit def applySeq[A: Writer](pairs: Seq[Product2[String, A]]): Seq[KeyValuePair] =
     pairs.map(apply[A])
 
-  implicit def applyIterable[A](pairs: Iterable[Product2[String, A]])(implicit writer: Write[A]): Iterable[KeyValuePair] =
+  implicit def applyIterable[A: Writer](pairs: Iterable[Product2[String, A]]): Iterable[KeyValuePair] =
     pairs.map(apply[A])
 
   def unapply(kvp: KeyValuePair) = Some(kvp.pair)
@@ -36,19 +47,20 @@ object KeyValuePair {
 
 
 class ScoredValue(val pair: Product2[Double, Stringified]) extends AnyVal {
-  @inline def score = pair._1
-  @inline def value = pair._2
+  def score: Double = pair._1
+  def value: Stringified = pair._2
 }
 
 object ScoredValue {
+  import Stringified._
 
   implicit def apply(pair: Product2[Double, Stringified]): ScoredValue =
     new ScoredValue(pair)
 
-  implicit def apply[A, B](pair: Product2[A, B])(implicit num: Numeric[A], writer: Write[B]): ScoredValue =
-    new ScoredValue((num.toDouble(pair._1), Stringified(pair._2)))
+  implicit def apply[A, B](pair: Product2[A, B])(implicit num: Numeric[A], writer: Writer[B]): ScoredValue =
+    new ScoredValue((num.toDouble(pair._1), pair._2.stringify))
 
-  implicit def applySeq[A, B](pairs: Seq[Product2[A, B]])(implicit num: Numeric[A], writer: Write[B]): Seq[ScoredValue] =
+  implicit def applySeq[A, B](pairs: Seq[Product2[A, B]])(implicit num: Numeric[A], writer: Writer[B]): Seq[ScoredValue] =
     pairs.map(apply[A, B])
 
   def unapply(sv: ScoredValue) = Some(sv.pair)

--- a/src/test/scala/com/redis/serialization/SerializationSpec.scala
+++ b/src/test/scala/com/redis/serialization/SerializationSpec.scala
@@ -37,8 +37,8 @@ class SerializationSpec extends FunSpec with Matchers  {
           }
         }
 
-      val write = implicitly[Write[Person]].write _
-      val read = implicitly[Read[Person]].read _
+      val write = implicitly[Writer[Person]].toByteString _
+      val read = implicitly[Reader[Person]].fromByteString _
 
       read(write(debasish)) should equal (debasish)
     }
@@ -47,7 +47,7 @@ class SerializationSpec extends FunSpec with Matchers  {
 
   describe("Stringified") {
 
-    it("should stringify String by default") {
+    it("should serialize String by default") {
       implicitly[String => Stringified].apply("string") should equal (Stringified("string"))
     }
 
@@ -59,13 +59,21 @@ class SerializationSpec extends FunSpec with Matchers  {
     it("should prioritize closer implicits") {
       @volatile var localWriterUsed = false
 
-      implicit val localWriter: Write[String] = Write { string =>
+      implicit val localWriter: Writer[String] = StringWriter { string =>
         localWriterUsed = true
         string
       }
 
       implicitly[String => Stringified].apply("string")
       localWriterUsed should be (true)
+    }
+
+    it("should not encode a byte array to a UTF-8 string") {
+      val nonUtf8Bytes = Array(0x85.toByte)
+
+      new String(nonUtf8Bytes, "UTF-8").getBytes("UTF-8") should not equal (nonUtf8Bytes)
+
+      Stringified(nonUtf8Bytes).value.toArray[Byte] should equal (nonUtf8Bytes)
     }
   }
 
@@ -79,11 +87,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val personFormat = jsonFormat2(Person)
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)
@@ -96,11 +104,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val format = org.json4s.DefaultFormats
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)
@@ -113,11 +121,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val format = org.json4s.DefaultFormats
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)
@@ -130,11 +138,11 @@ class SerializationSpec extends FunSpec with Matchers  {
 
         implicit val format = net.liftweb.json.DefaultFormats
 
-        val write = implicitly[Write[Person]].write _
-        val read = implicitly[Read[Person]].read _
+        val write = implicitly[Writer[Person]].toByteString _
+        val read = implicitly[Reader[Person]].fromByteString _
 
-        val writeL = implicitly[Write[List[Person]]].write _
-        val readL = implicitly[Read[List[Person]]].read _
+        val writeL = implicitly[Writer[List[Person]]].toByteString _
+        val readL = implicitly[Reader[List[Person]]].fromByteString _
 
         read(write(debasish)) should equal (debasish)
         readL(writeL(people)) should equal (people)


### PR DESCRIPTION
Here's new design draft.

General:
- Rename Read/Write to parameterized Reader/Writer and make them private[redis]
- ByteStringReader/Writer for Array[Byte] and ByteString
- trait Format[A] extends StringReader[A] with StringWriter[A]

Command-side:
- ~~Change Stringified to Serialized and wrap ByteString instead of String~~
- Refactor command serialization logic to deal with ByteString earlier

API:
- Revised `bitop` and `hmget` according to our multi-arg convention
