### PR TITLE
Fix parsing problem on more data

### DIFF
--- a/src/main/scala/com/redis/serialization/Deserializer.scala
+++ b/src/main/scala/com/redis/serialization/Deserializer.scala
@@ -15,6 +15,7 @@ class Deserializer {
     try {
       val rawReply = new RawReply(input)
       val result = (deserializerParts orElse errorPD)(rawReply)
+      parse = parseSafe
       Result.Ok(result, rawReply.remaining)
     } catch {
       case NotEnoughDataException =>


### PR DESCRIPTION
When a data response is split across 2 packets, the following response is incorrectly parsed - as the 'var parse' should be reverted to parseSafe.
