### PR TITLE
Timeout fix

### DIFF
--- a/src/test/scala/com/redis/RedisSpecBase.scala
+++ b/src/test/scala/com/redis/RedisSpecBase.scala
@@ -1,7 +1,7 @@
 package com.redis
 
 import scala.concurrent.duration._
-import akka.util.{Timeout => AkkaTimeout}
+import akka.util.Timeout
 import akka.actor._
 
 import org.scalatest._
@@ -20,7 +20,7 @@ trait RedisSpecBase extends FunSpec
   // Akka setup
   implicit val system = ActorSystem("redis-test-"+ iter.next)
   implicit val executionContext = system.dispatcher
-  implicit val timeout = AkkaTimeout(2 seconds)
+  implicit val timeout = akka.util.Timeout(2 seconds)
 
   // Scalatest setup
   implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))


### PR DESCRIPTION
Explicitly use Akka's timeout and remove the need for renaming the import to prevent namespace collisions.

Edit: woops should have put this change in...https://github.com/debasishg/scala-redis-nb/pull/67
