### PR TITLE
Add Travis CI before_script for install Redis 2.8.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ jdk:
   - oraclejdk7
   - openjdk7
 
-services:
-  - redis-server
+before_script:
+  - sh src/test/resources/setup_travis.sh

--- a/src/test/resources/setup_travis.sh
+++ b/src/test/resources/setup_travis.sh
@@ -1,0 +1,11 @@
+!/bin/sh
+
+# Install Redis
+wget http://download.redis.io/releases/redis-2.8.9.tar.gz
+tar -xzf redis-2.8.9.tar.gz
+cd redis-2.8.9
+make
+sudo make install
+
+# Start Redis Server
+/usr/local/bin/redis-server &


### PR DESCRIPTION
[Travis CI Environment](http://docs.travis-ci.com/user/ci-environment/), Redis version is 2.8.2 or 2.6.x.
[ZLEXCOUNT](http://redis.io/commands/zlexcount) command is available since 2.8.9.
So, SortedSetOperationsSpec has been failed after [this change](https://github.com/debasishg/scala-redis-nb/commit/a67e16d0dc3a70fd937204055b704e7623c5d726#diff-c21bfe19b73d4a08b76ca78e98c2fd8dR237).

```
The future returned an exception of type: com.redis.protocol.package$RedisError, with message: ERR unknown command 'ZLEXCOUNT'. (SortedSetOperationsSpec.scala:240)
```

Now, we have to install Redis 2.8.9 before build at Travis CI.

I have confirmed the build success at my repository.
https://travis-ci.org/zaneli/scala-redis-nb/builds/24392720
