### PR TITLE
HyperLogLog support

### DIFF
--- a/src/main/scala/com/redis/api/HyperLogLogOperations.scala
+++ b/src/main/scala/com/redis/api/HyperLogLogOperations.scala
@@ -1,0 +1,29 @@
+package com.redis
+package api
+
+import serialization._
+import akka.pattern.ask
+import akka.util.Timeout
+import com.redis.protocol.HyperLogLogCommands
+
+trait HyperLogLogOperations { this: RedisOps =>
+  import HyperLogLogCommands._
+
+  def pfadd(key: String, elements: Seq[String])(implicit timeout: Timeout) =
+    clientRef.ask(PFAdd(key, elements)).mapTo[PFAdd#Ret]
+
+  def pfadd(key: String, element: String, elements: String*)(implicit timeout: Timeout) =
+    clientRef.ask(PFAdd(key, element, elements: _*)).mapTo[PFAdd#Ret]
+
+  def pfcount(keys: Seq[String])(implicit timeout: Timeout) =
+    clientRef.ask(PFCount(keys)).mapTo[PFCount#Ret]
+
+  def pfcount(key: String, keys: String*)(implicit timeout: Timeout) =
+    clientRef.ask(PFCount(key, keys: _*)).mapTo[PFCount#Ret]
+
+  def pfmerge(destKey: String, sourceKeys: Seq[String])(implicit timeout: Timeout) =
+    clientRef.ask(PFMerge(destKey, sourceKeys)).mapTo[PFMerge#Ret]
+
+  def pfmerge(destKey: String, sourceKey: String, sourceKeys: String*)(implicit timeout: Timeout) =
+    clientRef.ask(PFMerge(destKey, sourceKey, sourceKeys: _*)).mapTo[PFMerge#Ret]
+}

--- a/src/main/scala/com/redis/api/RedisOps.scala
+++ b/src/main/scala/com/redis/api/RedisOps.scala
@@ -9,6 +9,7 @@ private [redis] trait RedisOps extends StringOperations
   with SetOperations
   with SortedSetOperations
   with HashOperations
+  with HyperLogLogOperations
   with KeyOperations
   with ServerOperations
   with EvalOperations

--- a/src/main/scala/com/redis/protocol/HyperLogLogCommands.scala
+++ b/src/main/scala/com/redis/protocol/HyperLogLogCommands.scala
@@ -1,0 +1,33 @@
+package com.redis.protocol
+
+import com.redis.serialization._
+
+
+object HyperLogLogCommands {
+  import DefaultWriters._
+
+  case class PFAdd(key: String, elements: Seq[String]) extends RedisCommand[Int]("PFADD") {
+    def params = key +: elements.toArgs
+  }
+
+  object PFAdd {
+    def apply(key: String, element: String, elements: String*): PFAdd = PFAdd(key, element +: elements)
+  }
+
+  case class PFCount(keys: Seq[String]) extends RedisCommand[Long]("PFCOUNT") {
+    def params = keys.toArgs
+  }
+
+  object PFCount {
+    def apply(key: String, keys: String*): PFCount = PFCount(key +: keys)
+  }
+
+  case class PFMerge(destKey: String, sourceKeys: Seq[String]) extends RedisCommand[Boolean]("PFMERGE") {
+    def params = destKey +: sourceKeys.toArgs
+  }
+
+  object PFMerge {
+    def apply(destKey: String, sourceKey: String, sourceKeys: String*): PFMerge =
+      PFMerge(destKey, sourceKey +: sourceKeys)
+  }
+}

--- a/src/test/scala/com/redis/api/HyperLogLogOperationsSpec.scala
+++ b/src/test/scala/com/redis/api/HyperLogLogOperationsSpec.scala
@@ -1,0 +1,52 @@
+package com.redis.api
+
+import org.scalatest.junit.JUnitRunner
+import org.junit.runner.RunWith
+import com.redis.RedisSpecBase
+
+
+@RunWith(classOf[JUnitRunner])
+class HyperLogLogOperationsSpec extends RedisSpecBase {
+
+  describe("pfadd") {
+    it("should add all the elements") {
+      val key = "pfadd1"
+      client.pfadd(key, "a", "b", "c", "d", "e").futureValue should be(1)
+      client.pfcount(key).futureValue should be(5)
+    }
+
+    it("should ignore duplicated elements (with very low error rate)") {
+      val key1 = "pfcount1"
+      client.pfadd(key1, "foo", "bar", "zap").futureValue should be(1)
+      client.pfadd(key1, "zap", "zap", "zap").futureValue should be(0)
+      client.pfadd(key1, "foo", "bar").futureValue should be(0)
+    }
+  }
+
+  describe("pfcount") {
+    it("should return the approximated cardinality") {
+      val key1 = "pfcount1"
+      client.pfadd(key1, "foo", "bar", "zap").futureValue should be(1)
+      client.pfcount(key1).futureValue should be(3)
+
+      val key2 = "pfcount2"
+      client.pfadd(key2, "1", "2", "3").futureValue should be(1)
+      client.pfcount(key1, key2).futureValue should be(6)
+    }
+  }
+
+  describe("pfmerge") {
+    it("should merge multiple HyperLogLog values") {
+      val key1 = "pfmerge1"
+      val key2 = "pfmerge2"
+      val key3 = "pfmerge3"
+
+      client.pfadd(key1, "foo", "bar", "zap", "a").futureValue should be(1)
+      client.pfadd(key2, "a", "b", "c", "foo").futureValue should be(1)
+
+      client.pfmerge(key3, key1, key2).futureValue should be(true)
+
+      client.pfcount(key3).futureValue should be (6)
+    }
+  }
+}


### PR DESCRIPTION
Support for HyperLogLog data structure available since Redis 2.8.9. [1]

Added commands:
- PFADD
- PFCOUNT
- PFMERGE

[1] http://antirez.com/news/75
