### PR TITLE
Pub/Sub support.

### DIFF
--- a/src/main/scala/com/redis/PubSubHandler.scala
+++ b/src/main/scala/com/redis/PubSubHandler.scala
@@ -1,0 +1,22 @@
+package com.redis
+
+import akka.actor.{Props,ActorLogging, Actor}
+import akka.routing.Listeners
+import com.redis.protocol.PubSubCommands
+
+object PubSubHandler {
+
+  def props = Props[PubSubHandler]
+
+}
+
+class PubSubHandler extends Actor with ActorLogging with Listeners {
+
+  val handleEvents : Receive = {
+    case e : PubSubCommands.PushedMessage =>
+      log.debug( s"Event received $e" )
+      gossip( e )
+  }
+
+  override def receive: Receive = listenerManagement orElse handleEvents
+}

--- a/src/main/scala/com/redis/api/PubSubOperations.scala
+++ b/src/main/scala/com/redis/api/PubSubOperations.scala
@@ -1,0 +1,79 @@
+package com.redis.api
+
+import akka.actor.ActorRef
+import akka.util.Timeout
+import com.redis.serialization.Stringified
+
+trait PubSubOperations { this: RedisOps =>
+  import com.redis.protocol.PubSubCommands._
+  import akka.pattern.ask
+
+  /**
+   * SUBSCRIBE
+   * Subscribes the client to the specified channels.
+   * Once the client enters the subscribed state it is not supposed to issue any other commands,
+   * except for additional SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE commands.
+   *
+   * Any command, except of QUIT, SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE will fail
+   * with [[com.redis.RedisConnection.CommandRejected]] cause.
+   *
+   * The actor passed in the listener parameter will receive messages from all channels
+   * the underlying client is subscribed to. It means, every listeners registered with the
+   * client will receive messages from all channels, no matter which combinations of
+   * listeners and channels were passed to the call(s).
+   *
+   * The result of the command is not available directly. The listener will receive one or
+   * more [[Subscribed]] events in the case of success.
+   */
+  def subscribe( listener: ActorRef, channels: Seq[String] )(implicit timeout: Timeout) = {
+    clientRef.tell( Subscribe(channels), listener )
+  }
+
+  def subscribe( listener: ActorRef, channel: String, channels: String* )(implicit timeout: Timeout) = {
+    clientRef.tell( Subscribe(channel, channels: _*), listener )
+  }
+
+  /**
+   * UNSUBSCRIBE
+   * Unsubscribes the client from the given channels, or from all of them if none is given.
+   * When no channels are specified, the client is unsubscribed from all the previously subscribed channels.
+   * In this case, a message for every unsubscribed channel will be sent to the client.
+   *
+   * The operation affects all listeners registered with the client. A result of the operation will be
+   * reported to listeners via [[Unsubscribed]] messages.
+   */
+  def unsubscribe(channels: String* )(implicit timeout: Timeout) : Unit = {
+    clientRef ! Unsubscribe(channels)
+  }
+
+  /**
+   * PUBLISH
+   * Posts a message to the given channel.
+   */
+  def publish(channel: String, message: Stringified)(implicit timeout: Timeout) = {
+    clientRef.ask( Publish(channel, message) ).mapTo[Publish#Ret]
+  }
+
+  /**
+   * PSUBSCRIBE
+   * Subscribes the client to the given patterns.
+   *
+   * See [[subscribe()]] for more details.
+   */
+  def psubscribe(listener: ActorRef, patterns: Seq[String])(implicit timeout: Timeout) = {
+    clientRef.tell( PSubscribe(patterns), listener )
+  }
+
+  def psubscribe( listener: ActorRef, pattern: String, patterns: String*)(implicit timeout: Timeout) = {
+    clientRef.tell( PSubscribe(pattern, patterns:_*), listener )
+  }
+
+  /**
+   * PUNSUBSCRIBE
+   * Unsubscribes the client from the given patterns, or from all of them if none is given.
+   */
+  def punsubscribe( patterns: String*)(implicit timeout: Timeout) = {
+    clientRef ! PUnsubscribe(patterns)
+  }
+
+}

--- a/src/main/scala/com/redis/api/RedisOps.scala
+++ b/src/main/scala/com/redis/api/RedisOps.scala
@@ -14,7 +14,8 @@ private [redis] trait RedisOps extends StringOperations
   with ServerOperations
   with EvalOperations
   with ConnectionOperations
-  with TransactionOperations {
+  with TransactionOperations
+  with PubSubOperations {
 
   def clientRef: ActorRef
 }

--- a/src/main/scala/com/redis/protocol/PubSubCommands.scala
+++ b/src/main/scala/com/redis/protocol/PubSubCommands.scala
@@ -1,0 +1,50 @@
+package com.redis.protocol
+
+import akka.util.ByteString
+
+object PubSubCommands {
+  import com.redis.serialization._
+  import DefaultFormats._
+
+  sealed trait PushedMessage {
+    def destination: String
+  }
+  case class Subscribed(destination: String, isPattern: Boolean, numOfSubscriptions: Int) extends PushedMessage
+  case class Unsubscribed(destination: String, isPattern: Boolean, numOfSubscriptions: Int) extends PushedMessage
+  case class Message(destination: String, payload: ByteString) extends PushedMessage
+  case class PMessage(pattern: String, destination: String, payload: ByteString) extends PushedMessage
+
+  abstract class PubSubCommand(_cmd: String) extends RedisCommand[Unit](_cmd)(PartialDeserializer.UnitDeserializer)
+  abstract class SubscribeCommand(_cmd: String) extends PubSubCommand(_cmd)
+
+  case class Subscribe(channels: Seq[String]) extends SubscribeCommand("SUBSCRIBE") {
+    require(channels.nonEmpty)
+    def params = channels.toArgs
+  }
+
+  object Subscribe {
+    def apply(channel: String, channels: String*) = new Subscribe( channel +: channels )
+  }
+
+  case class PSubscribe( patterns: Seq[String] ) extends SubscribeCommand("PSUBSCRIBE") {
+    require(patterns.nonEmpty)
+    def params = patterns.toArgs
+  }
+
+  object PSubscribe {
+    def apply(pattern: String, patterns: String*) : PSubscribe = PSubscribe( pattern +: patterns )
+  }
+
+  case class Unsubscribe(channels: Seq[String]) extends PubSubCommand("UNSUBSCRIBE") {
+    override def params = channels.toArgs
+  }
+
+  case class PUnsubscribe(patterns: Seq[String]) extends PubSubCommand("PUNSUBSCRIBE") {
+    override def params = patterns.toArgs
+  }
+
+  case class Publish(channel: String, value: Stringified) extends RedisCommand[Int]("PUBLISH") {
+    override def params: Args = channel +: value +: ANil
+  }
+
+}

--- a/src/main/scala/com/redis/serialization/PartialDeserializer.scala
+++ b/src/main/scala/com/redis/serialization/PartialDeserializer.scala
@@ -5,7 +5,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.collection.{Iterator, GenTraversable}
 import scala.language.higherKinds
 import scala.annotation.implicitNotFound
-import com.redis.protocol.Err
+import com.redis.protocol._
 import RawReplyParser._
 
 
@@ -38,6 +38,15 @@ object PartialDeserializer extends LowPriorityPD {
   implicit def listPD[A](implicit pd: PartialDeserializer[A]) = multiBulkPD[A, List]
 
   val errorPD = _errorPD
+
+  implicit val pubSubMessagePD = _pubSubMessagePD
+
+  // Is needed to implement Pub/Sub messages, since they have no direct result.
+  implicit val UnitDeserializer = new PartialDeserializer[Unit] {
+    override def isDefinedAt(x: RawReply): Boolean = true
+
+    override def apply(v1: RawReply): Unit = ()
+  }
 }
 
 private[serialization] trait LowPriorityPD extends CommandSpecificPD {

--- a/src/test/scala/com/redis/api/PubSubOperationsSpec.scala
+++ b/src/test/scala/com/redis/api/PubSubOperationsSpec.scala
@@ -1,0 +1,113 @@
+package com.redis.api
+
+import akka.util.ByteString
+import com.redis.RedisConnection.CommandRejected
+import com.redis.{RedisClient, RedisSpecBase}
+
+import scala.concurrent.Await
+
+class PubSubOperationsSpec extends RedisSpecBase {
+  import com.redis.protocol.PubSubCommands._
+
+import scala.concurrent.duration._
+
+  def withClientPerTest( testCode : RedisClient => Any ): Unit = {
+    val redisClient = RedisClient("localhost", 6379)
+    try { testCode(redisClient) } finally redisClient.quit()
+  }
+
+  def sendReceive(channel: String, message: String): Unit = {
+    client.publish(channel, message).futureValue should equal(1)
+    val msg = expectMsgType[Message]
+    msg.payload should equal( ByteString(message) )
+  }
+
+  def psendReceive(channel: String, message: String): Unit = {
+    client.publish(channel, message).futureValue should equal(1)
+    val msg = expectMsgType[PMessage]
+    msg.payload should equal( ByteString(message) )
+  }
+
+  describe("Pub/Sub") {
+
+    it("should subscribe to some channels and deliver subscription notifications") {
+      withClientPerTest { subClient =>
+        subClient.subscribe(testActor, "first", "second")
+        expectMsgAllOf( Subscribed("first", false, 1), Subscribed("second", false, 2) )
+      }
+    }
+
+    it("accepts only QUIT, SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE  while in the subscribed state") {
+      withClientPerTest { subClient =>
+        subClient.subscribe( testActor, "first" )
+        expectMsgType[Subscribed]
+        val future = subClient.set("key", "value")
+        Await.result( future.failed, 1.second ) shouldBe a [CommandRejected]
+      }
+    }
+
+    it("subscription can be canceled") {
+      withClientPerTest { subClient =>
+        subClient.subscribe(testActor, "first", "second")
+        expectMsgType[Subscribed]
+        expectMsgType[Subscribed]
+
+        sendReceive( "first", "1" )
+
+        subClient.unsubscribe("second")
+        expectMsgType[Unsubscribed]
+        sendReceive("first", "2")
+        client.publish("second", "3").futureValue should equal(0)
+        expectNoMsg()
+      }
+    }
+
+    it("Should be able publish messages") {
+      withClientPerTest { subClient =>
+        subClient.clientRef tell (Subscribe("first"), testActor)
+        expectMsg( Subscribed("first", false, 1) )
+
+        sendReceive("first", "something")
+      }
+    }
+
+    it("allows to subscribe to the further channels") {
+      withClientPerTest { subClient =>
+        subClient.subscribe( testActor, "1")
+        expectMsgType[Subscribed]
+        client.publish("2", "msg").futureValue should equal(0)
+        expectNoMsg(1.second)
+        subClient.subscribe( testActor, "2" )
+        expectMsgType[Subscribed]
+        sendReceive("2", "msg")
+      }
+    }
+
+    it("allows to subscribe and unsubscribe using patterns") {
+      withClientPerTest { subClient =>
+        val pattern = "h?llo"
+        subClient.psubscribe( testActor, pattern)
+        expectMsgType[Subscribed]
+
+        psendReceive("hello", "hellomsg")
+        psendReceive("hallo", "hallomsg")
+
+        subClient.punsubscribe( "hell?" )
+        client.publish("hillo", "hellomsg")
+        client.publish("hallo", "hallomsg")
+        expectMsgType[Unsubscribed]
+        // still receive messages
+        expectMsgType[PMessage]
+        expectMsgType[PMessage]
+
+        subClient.punsubscribe(pattern)
+        expectMsgType[Unsubscribed]
+        client.publish("hillo", "hellomsg")
+        client.publish("hallo", "hallomsg")
+        expectNoMsg()
+
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
A basic Publish/Subscribe support. 
- Actors can be registered as listeners with a client. Support for Akka Streams or scalaz-streams can be added in the future.
- Every listener receives messages from all channels the client is subscribed to.
- Unsubscription affects all listeners registered with the client.
- Payload of the received messages is not deserialized and passed as ByteString wrapped with the Message object to the listener. The reason for this limitation is that I'm not sure, what he best way to register and select the proper deserializer would be. Anyway, it is straightforward to implement the deserialization logic as part of the listener's receive method.

I've implemented this functionality because i would like to use high availability (sentinel) capabilities in my current project and Pub/Sub could be very useful for implementing it. If you are interested in adding the sentinel support to the driver I would be happy to contribute it.
