### PR TITLE
remove oraclejdk7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ scala:
   - 2.11.8
 
 jdk:
-  - oraclejdk7
   - openjdk7
 
 before_script:


### PR DESCRIPTION
travis-ci no longer support oraclejdk7

https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879

> My guess is that we can no longer support oraclejdk7 on our recent build images due to Oracle's withdrawal. http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html